### PR TITLE
Add company intelligence CLI and data fetchers

### DIFF
--- a/docs/PR_SUMMARY.md
+++ b/docs/PR_SUMMARY.md
@@ -1,0 +1,3 @@
+# Company Intelligence Tool
+
+This branch introduces a Python CLI that compiles public company data (press releases, earnings/IR, industry coverage, competitors) and generates a sales-focused report for ads, sales, and recruiting use cases.


### PR DESCRIPTION
This PR introduces a Python CLI tool that generates sales-focused company intelligence reports.

Highlights:
- CLI to ingest company name + website and output Markdown/JSON
- Fetchers for press/newsroom, earnings/IR, industry coverage, competitors (via ddgs)
- Heuristic summarizer tailored to ads, sales, and recruiting use cases
- README with setup and usage instructions

Includes a brief doc in docs/PR_SUMMARY.md.
