### PR TITLE
Integrate UI with companyintel backend + filtering

### DIFF
--- a/microsoft_report.json
+++ b/microsoft_report.json
@@ -23,17 +23,17 @@
         "published_at": null
       },
       {
-        "title": "FY23 Q2 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2023-q2/press-release-webcast",
-        "snippet": "Microsoft returned $9.7 billion to shareholders in the form of share repurchases and dividends in the second quarter of fiscal year 2023, a decrease of 11% ...",
+        "title": "FY25 Q4 - Press Releases - Investor Relations",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "snippet": "Jul 30, 2025 — Earnings Release FY25 Q4 · Revenue was $76.4 billion and increased 18% (up 17% in constant currency) · Operating income was $34.3 billion and ...",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "FY25 Q4 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
-        "snippet": "Jul 30, 2025 — Earnings Release FY25 Q4 · Revenue was $76.4 billion and increased 18% (up 17% in constant currency) · Operating income was $34.3 billion and ...",
+        "title": "FY23 Q2 - Press Releases - Investor Relations",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2023-q2/press-release-webcast",
+        "snippet": "Microsoft returned $9.7 billion to shareholders in the form of share repurchases and dividends in the second quarter of fiscal year 2023, a decrease of 11% ...",
         "content": null,
         "source": "ddg",
         "published_at": null
@@ -95,46 +95,6 @@
         "published_at": null
       },
       {
-        "title": "Democracy Forward - Protecting Democracy | Microsoft CSR",
-        "url": "https://www.microsoft.com/en-us/corporate-responsibility/democracy-forward",
-        "snippet": "Microsoft is working to stem threats to democracy by helping to secure elections, protect voting rights, and support journalists through our Democracy Forward program.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft AI Blogs | Artificial Intelligence News and Updates",
-        "url": "https://www.microsoft.com/en-us/ai/blog/",
-        "snippet": "6 days ago · Microsoft AI Blog keeps you up-to-date about the latest advancements in artificial intelligence and their integration into our products and platforms.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft Research Lab - Redmond ...",
-        "url": "https://www.microsoft.com/en-us/research/lab/microsoft-research-redmond/news-and-awards/?pg=54",
-        "snippet": "Computer science research supporting the future of the connected world with secure computing that enriches lives and empowers everyone.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft 365 Copilot News and Insights",
-        "url": "https://www.microsoft.com/en-us/microsoft-365/blog/product/microsoft-365-copilot/",
-        "snippet": "Learn how this AI-powered assistant enhances productivity by seamlessly integrating with your Microsoft 365 apps, documents, and conversations.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "News | Microsoft Copilot Blog",
-        "url": "https://www.microsoft.com/en-us/microsoft-copilot/blog/content-type/news/",
-        "snippet": "Take the power of AI on the go with the Copilot app . Your everyday AI companion. Download for a 1-month free trial of Copilot Pro! Download.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
         "title": "Microsoft 365 News | Microsoft 365 Blog",
         "url": "https://www.microsoft.com/en-us/microsoft-365/blog/content-type/news/",
         "snippet": "4 days ago · Microsoft 365 Blog highlights the latest News to keep you in-the-know on Windows 11 and 365, Teams, Viva, and more.",
@@ -159,6 +119,22 @@
         "published_at": null
       },
       {
+        "title": "Democracy Forward - Protecting Democracy | Microsoft CSR",
+        "url": "https://www.microsoft.com/en-us/corporate-responsibility/democracy-forward",
+        "snippet": "Microsoft is working to stem threats to democracy by helping to secure elections, protect voting rights, and support journalists through our Democracy Forward program.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft AI Blogs | Artificial Intelligence News and Updates",
+        "url": "https://www.microsoft.com/en-us/ai/blog/",
+        "snippet": "6 days ago · Microsoft AI Blog keeps you up-to-date about the latest advancements in artificial intelligence and their integration into our products and platforms.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
         "title": "Microsoft FY25 Q4 Earnings",
         "url": "https://www.microsoft.com/en-us/investor/default",
         "snippet": "We’re sharing a summary of our work in progress to create a more inclusive, sustainable, and trusted future. We cannot accomplish this alone—it will take all of us, working and learning together.",
@@ -167,103 +143,111 @@
         "published_at": null
       },
       {
-        "title": "Press releases Archives - Source",
+        "title": "Remotedesktop-Server-Lizenzierung",
+        "url": "https://activate.microsoft.com/MoreInfo.aspx?lang=de",
+        "snippet": "Microsoft Newsroom .",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Remotedesktop-Server-Lizenzierung",
+        "url": "https://activate.microsoft.com/Default.aspx?locale=de-de",
+        "snippet": "Microsoft Newsroom .",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Remotedesktop-Server-Lizenzierung",
+        "url": "https://activate.microsoft.com/Faq.aspx?locale=de-de",
+        "snippet": "Microsoft Newsroom .",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft News Press releases Archives - Source",
         "url": "https://news.microsoft.com/source/tag/press-releases/",
-        "snippet": "Press releases Results Page (10435 results). September 15, 2025. Microsoft announces quarterly dividend increase · Company News. September 10, 2025. NEA ...",
+        "snippet": "July 9, 2025 - Microsoft earnings press release available on Investor Relations website · Company News · April 30, 2025 · Microsoft Cloud and AI strength drives third quarter results · Company News · April 9, 2025 · Microsoft announces quarterly earnings release date ·",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Corporation (MSFT) Latest Press Releases ...",
+        "title": "Yahoo! Finance Microsoft Corporation (MSFT) Latest Press Releases & Corporate News - Yahoo Finance",
         "url": "https://finance.yahoo.com/quote/MSFT/press-releases/",
-        "snippet": "Get the latest Microsoft Corporation (MSFT) stock news and headlines to help you in your trading and investing decisions.",
+        "snippet": "2 weeks ago - Get the latest Microsoft Corporation (MSFT) stock news and headlines to help you in your trading and investing decisions.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Corporation (MSFT) Press Releases",
-        "url": "https://www.nasdaq.com/market-activity/stocks/msft/press-releases",
-        "snippet": "Latest Press Releases · NEA receives Microsoft grant to expand AI literacy and leadership · NFL and Microsoft expand partnership to bring Copilot to the ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Press Release Archives - Microsoft Stories Asia",
-        "url": "https://news.microsoft.com/apac/category/press-release/",
-        "snippet": "Microsoft announces US$2.2 billion investment to fuel Malaysia's cloud and AI transformation, Microsoft announces significant commitments to enable a cloud and ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft Source",
-        "url": "https://news.microsoft.com/source/",
-        "snippet": "The latest news and stories about how technology is helping people around the world solve problems, innovate and do more each day.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "FY25 Q4 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
-        "snippet": "Jul 30, 2025 — Earnings Release FY25 Q4 · Revenue was $76.4 billion and increased 18% (up 17% in constant currency) · Operating income was $34.3 billion and ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Latest news - Source",
-        "url": "https://news.microsoft.com/source/view-all/",
-        "snippet": "Latest news ; Microsoft announces quarterly dividend increase ; Celebrating Hispanic Heritage Month with Xbox ; IFA 2025: Accelerating innovation with Copilot+ PCs ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Investor Relations",
+        "title": "Microsoft Home page",
         "url": "https://www.microsoft.com/en-us/investor/default",
-        "snippet": "NEWS · Microsoft announces quarterly dividend increase · Celebrating Hispanic Heritage Month with Xbox · IFA 2025: Accelerating innovation with Copilot+ PCs and ...",
+        "snippet": "16 hours ago - How Microsoft ’s customers and partners accelerated AI Transformation in FY25 to innovate with purpose and shape their future success ... We’re sharing a summary of our work in progress to create a more inclusive, sustainable, and trusted future. We cannot accomplish this alone—it will take all of us, working and learning together. ... The next earnings release ...",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Resources - Source",
+        "title": "Microsoft FY25 Q4 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
+        "snippet": "July 30, 2025 - Microsoft (Nasdaq “MSFT” @microsoft) creates platforms and tools powered by AI to deliver innovative solutions that meet the evolving needs of our customers . The technology company is committed to making AI available broadly and doing so responsibly, with a mission to empower every person ...",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Nasdaq Microsoft Corporation (MSFT) Latest Press Releases and Corporate News | Nasdaq",
+        "url": "https://www.nasdaq.com/market-activity/stocks/msft/press-releases",
+        "snippet": "Get the latest insights on Microsoft Corporation Common Stock (MSFT) with press releases and corporate news to help you in your trading and investing decisions.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft FY22 Q2 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2022-q2/press-release-webcast",
+        "snippet": "Microsoft will provide forward-looking guidance in connection with this quarterly earnings announcement on its earnings conference call and webcast. Quarterly Highlights, Product Releases , and Enhancements",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft News Resources - Source",
         "url": "https://news.microsoft.com/source/resources/",
-        "snippet": "Press Resources ... Get all the latest information about Microsoft news and innovation , leadership and recent events, as well as photos, videos and transcripts.",
+        "snippet": "March 10, 2025 - Get the latest AI news and learn how technology is transforming the way people live and work · Microsoft’s global network of datacenters enable critical services, remote work, AI and more",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Recent News - Stories",
+        "title": "Microsoft Recent News - Stories",
         "url": "https://news.microsoft.com/recent-news/",
-        "snippet": "Microsoft earnings press release available on Investor Relations website . April 30, 2025. Microsoft Cloud and AI strength drives third quarter results. April 9 ...",
+        "snippet": "June 15, 2018 - April 9, 2025 Microsoft announces quarterly earnings release date",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft Press Materials - Stories",
+        "url": "https://news.microsoft.com/manufacturing-press-materials/",
+        "snippet": "January 6, 2017 - CES 2017 Microsoft Connected Vehicle Platform helps automakers transform cars January 5, 2017 Official Microsoft Blog Helping automakers drive innovation through connected cars January 5, 2017 IoT blog BMW at the Consumer Electronics Show (CES) 2017 in Las Vegas January 5, 2017 BMW press release ...",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft The Official Microsoft Blog",
+        "url": "https://blogs.microsoft.com/",
+        "snippet": "1 week ago - Sep 11, 2025 | Microsoft Corporate Blogs · Sep 9, 2025 | Amy Coleman - Executive Vice President, Chief People Officer",
         "content": null,
         "source": "ddg",
         "published_at": null
       }
     ],
     "earnings_reports": [
-      {
-        "title": "Media Alert: Martin Taylor Webcast for Microsoft Investor Relations ...",
-        "url": "https://news.microsoft.com/2004/02/25/media-alert-martin-taylor-webcast-for-microsoft-investor-relations/",
-        "snippet": "Martin Taylor, General Manager, Platform Strategy. What: As part of an ongoing speaker series from the Investor Relations team, Taylor will discuss Microsofts competitive strategy efforts...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft announces quarterly dividend increase",
-        "url": "https://news.microsoft.com/source/2025/09/15/microsoft-announces-quarterly-dividend-increase-6/",
-        "snippet": "For more information, financial analysts and investors only: Jonathan Neilson, Vice President, Investor Relations , (425) 706-4400.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
       {
         "title": "Information for Investors",
         "url": "https://www.microsoft.com/en-us/investor/investor-information",
@@ -289,17 +273,17 @@
         "published_at": null
       },
       {
-        "title": "Filter SEC Filings - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/sec-filings",
-        "snippet": "Recent quarterly and annual filings are available from this web site in Microsoft Word format . Expanded and historical information is available from a third- ...",
+        "title": "Microsoft Investor Relations - Contact Information",
+        "url": "https://www.microsoft.com/en-us/investor/contact-information",
+        "snippet": "Questions related to Microsoft finance or stock. E-mail: msft@microsoft.com. Phone: ( 800) 285-7772 (United States) (425) 706-4400 (International).",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Investor Relations - Contact Information",
-        "url": "https://www.microsoft.com/en-us/investor/contact-information",
-        "snippet": "Questions related to Microsoft finance or stock. E-mail: msft@microsoft.com. Phone: ( 800) 285-7772 (United States) (425) 706-4400 (International).",
+        "title": "Microsoft Investor Relations - SEC Filings",
+        "url": "https://www.microsoft.com/en-us/investor/sec-filings",
+        "snippet": "Recent quarterly and annual filings are available from this web site in Microsoft Word format . Expanded and historical information is available from a third- ...",
         "content": null,
         "source": "ddg",
         "published_at": null
@@ -329,161 +313,177 @@
         "published_at": null
       },
       {
-        "title": "Earnings Release FY25 Q3 - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q3/performance",
-        "snippet": "Cost of revenue increased $3.4 billion or 18 % driven by growth in Microsoft Cloud. Gross margin increased $4.8 billion or 11% with growth across each of our ...",
+        "title": "Microsoft Investor Relations - Annual Reports",
+        "url": "https://www.microsoft.com/en-us/investor/annual-reports",
+        "snippet": "Shareholders may opt for the convenience of electronic shareholder materials. Subscribers receive messages containing links to the online annual report and ...",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Segment Revenue and Operating Income - FY25 Q1",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/segment-revenues",
-        "snippet": "Download Earnings Related Files · Earnings Call Slides · Earnings Call Transcript · Financial Statements · Outlook · Press Release · 10Q · FY25Q1 Product ...",
+        "title": "FY25 Q1 - Performance - Investor Relations",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/performance",
+        "snippet": "Performance. Revenue increased $9.1 billion or 16 % driven by growth across each of our segments. Intelligent Cloud revenue increased driven by Azure.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "More Personal Computing Performance - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/more-personal-computing-performance",
-        "snippet": "More Personal Computing Revenue increased $1.9 billion or 17%. Windows and Devices revenue decreased slightly. Windows OEM and Devices revenue increased 2%.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft FY25 Fourth Quarter Earnings Conference Call",
-        "url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
-        "snippet": "Jul 30, 2025 — We expect COGS of $24.3 to $24.5 billion or growth of 21% to 22% and operating expense of $15.7 to $15.8 billion or growth of 5% to 6%.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Earnings Release FY25 Q2 - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q2/performance",
-        "snippet": "Performance. Revenue increased $7.6 billion or 12 % driven by growth in Intelligent Cloud and Productivity and Business Processes. Intelligent Cloud revenue ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft FY25 Third Quarter Earnings Conference Call",
-        "url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q3",
-        "snippet": "Apr 30, 2025 — This quarter, revenue was $70.1 billion, up 13% and 15% in constant currency. Gross margin dollars increased 11% and 13% in constant currency ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "FY25 Q4 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
-        "snippet": "Jul 30, 2025 — Earnings Release FY25 Q4 · Revenue was $76.4 billion and increased 18% (up 17% in constant currency) · Operating income was $34.3 billion and ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Investor Relations",
+        "title": "Microsoft Home page",
         "url": "https://www.microsoft.com/en-us/investor/default",
-        "snippet": "Know the next earnings release date. Presentation The next earnings release will be announced soon . Know the dates for the quarterly dividend.",
+        "snippet": "The next earnings release will be announced soon.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Default",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/default",
-        "snippet": "Earnings & Financials. Earnings Releases Earnings Releases. Press Release & Webcast · Financial Statements · Performance · Metrics · Segment Results. Financial ...",
+        "title": "Microsoft Microsoft Fiscal Year 2025 Fourth Quarter Earnings Conference Call",
+        "url": "https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4",
+        "snippet": "On the Microsoft Investor Relations website, you can find our earnings press release and financial summary slide deck, which is intended to supplement our prepared remarks during today’s call and provides the reconciliation of differences between GAAP and non-GAAP financial measures.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "FY24 Q1 - Performance - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2024-q1/performance",
-        "snippet": "Revenue increased $3.5 billion or 7 % driven by growth in Intelligent Cloud and Productivity and Business Processes, offset in part by a decline in More ...",
+        "title": "Microsoft FY25 Q1 - Segment Revenue and Operating Income - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/segment-revenues",
+        "snippet": "Information contained in these documents is current as of the earnings date, and not restated for new accounting standards",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft earnings press release available on Investor ...",
-        "url": "https://www.prnewswire.com/news-releases/microsoft-earnings-press-release-available-on-investor-relations-website-302517844.html",
-        "snippet": "Jul 30, 2025 · REDMOND, Wash., July 30, 2025 /PRNewswire/ -- Microsoft Corp. on Wednesday announced that fiscal year 2025 fourth-quarter financial results are available on its Investor Relations website.",
+        "title": "Microsoft FY25 Q4 - Cash Flows - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/Investor/earnings/FY-2025-Q4/cash-flows?msockid=2df94fec3e2b6c39381159883ff06dfa",
+        "snippet": "Information contained in these documents is current as of the earnings date, and not restated for new accounting standards",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "FY24 Q4 - Press Releases - Investor Relations - Microsoft",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2024-q4/press-release-webcast",
-        "snippet": "“We closed out our fiscal year with a solid quarter, highlighted by record bookings and Microsoft Cloud quarterly revenue of $36.8 billion, up 21% (up 22% in constant currency) year-over-year,” said Amy Hood, executive vice president and chief financial officer of Microsoft .",
+        "title": "Microsoft FY25 Q4 - More Personal Computing Performance - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/more-personal-computing-performance",
+        "snippet": "Information contained in these documents is current as of the earnings date, and not restated for new accounting standards",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft climbs to $4 trillion in after-hours trading on ...",
-        "url": "https://fortune.com/2025/07/30/microsoft-earnings-blowout-fourth-quarter-4-trillion-market-cap-ai/",
-        "snippet": "Jul 31, 2025 · Microsoft delivered a blockbuster quarter to close its 2025 fiscal year, riding the wave of surging demand for cloud and AI services and sending its stock to new heights in after-hours trading.",
+        "title": "Microsoft FY25 Q4 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast?msockid=2fae7bd15d7963de26236db55c6362b2",
+        "snippet": "Microsoft will provide forward-looking guidance in connection with this quarterly earnings announcement on its earnings conference call and webcast.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Corporation (MSFT) Latest Press Releases ...",
-        "url": "https://finance.yahoo.com/quote/MSFT/press-releases/?fr=sycsrp_catchall",
-        "snippet": "Get the latest Microsoft Corporation (MSFT) stock news and headlines to help you in your trading and investing decisions.",
+        "title": "Microsoft Microsoft Fiscal Year 2024 Fourth Quarter Earnings Conference Call",
+        "url": "https://www.microsoft.com/en-us/investor/events/fy-2024/earnings-fy-2024-q4",
+        "snippet": "On the Microsoft Investor Relations website, you can find our earnings press release and financial summary slide deck, which is intended to supplement our prepared remarks during today’s call and provides the reconciliation of differences between GAAP and non-GAAP financial measures.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft (MSFT) Q4 earnings report 2025 - CNBC",
-        "url": "https://www.cnbc.com/2025/07/30/microsoft-msft-q4-earnings-report-2025.html",
-        "snippet": "Jul 30, 2025 · Microsoft said revenue jumped 18% from a year earlier. The company reported revenue from Azure and cloud services for the first time, with sales exceeding $75 billion for fiscal 2025. The stock,...",
+        "title": "Microsoft Microsoft Investor Relations - Microsoft Corporation Overview Board Of Directors",
+        "url": "https://www.microsoft.com/en-us/investor/corporate-governance/board-of-directors?mstLocPickShow=True&NavToggle=True&navItemId=m-earnings-and-financials?mstLocPickShow=True&NavToggle=True&navItemId=m-earnings-and-financials",
+        "snippet": "The Board maintains four standing committees to assist it in discharging its oversight responsibilities. Each committee performs its duties as assigned by the Board in compliance with Microsoft's Bylaws and its charter · The directors who serve on these committees are independent.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft earnings press release available on Investor ...",
-        "url": "https://www.gurufocus.com/news/3018355/microsoft-earnings-press-release-available-on-investor-relations-website--msft-stock-news",
-        "snippet": "Jul 30, 2025 · Microsoft Corp. (MSFT, Financial) reported robust financial results for Q4 FY2025, driven by strong performance in its cloud and AI divisions. The tech giant posted a total revenue of $76.4 billion, marking an 18% increase over the previous year's quarter.",
+        "title": "Microsoft FY25 Q4 - Comprehensive Income - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/comprehensive-income",
+        "snippet": "Information contained in these documents is current as of the earnings date, and not restated for new accounting standards",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft releases earnings results",
-        "url": "https://www.stocktitan.net/news/MSFT/microsoft-earnings-press-release-available-on-investor-relations-906z9zh2lg1v.html",
-        "snippet": "Jan 29, 2025 · Microsoft (MSFT) reported strong fiscal Q2 2025 results, with revenue reaching $69.6 billion, up 12% year-over-year. Operating income increased 17% to $31.7 billion, while net income grew 10% to $24.1 billion. Diluted earnings per share rose 10% to $3.23.",
+        "title": "Microsoft Moving sales, service, and finance to the Frontier with Microsoft 365 Copilot | Microsoft 365 Blog",
+        "url": "https://www.microsoft.com/en-us/microsoft-365/blog/2025/09/10/moving-sales-service-and-finance-to-the-frontier-with-microsoft-365-copilot/",
+        "snippet": "6 days ago - Microsoft is announcing the addition of role-based AI solutions to Microsoft 365 Copilot for sales, service, and finance professionals.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "FY25 Q4 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
-        "snippet": "Jul 30, 2025 — Microsoft returned $9.4 billion to shareholders in the form of dividends and share repurchases in the fourth quarter of fiscal year 2025. ...",
+        "title": "Microsoft News Microsoft announces quarterly earnings release date - Source",
+        "url": "https://news.microsoft.com/source/2025/07/09/microsoft-announces-quarterly-earnings-release-date-64/",
+        "snippet": "July 9, 2025 - — July 9, 2025 — Microsoft Corp. will publish fiscal year 2025 fourth-quarter financial results after the close of the market on Wednesday, July 30, 2025, on the Microsoft Investor Relations website at https://www.microsoft.com/en-us/Investor/. A live webcast of the earnings conference ...",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "FY25 Q3 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q3/press-release-webcast",
-        "snippet": "Apr 30, 2025 — Microsoft returned $9.7 billion to shareholders in the form of dividends and share repurchases in the third quarter of fiscal year 2025.",
+        "title": "Microsoft FY23 Q2 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/Investor/earnings/FY-2023-Q2/press-release-webcast",
+        "snippet": "July 30, 2024 - Microsoft will provide forward-looking guidance in connection with this quarterly earnings announcement on its earnings conference call and webcast. Quarterly Highlights, Product Releases , and Enhancements",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "FY25 Q2 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q2/press-release-webcast",
-        "snippet": "Jan 29, 2025 — Microsoft returned $9.7 billion to shareholders in the form of dividends and share repurchases in the second quarter of fiscal year 2025.",
+        "title": "Microsoft FY23 Q3 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/Investor/earnings/FY-2023-Q3/press-release-webcast",
+        "snippet": "July 29, 2024 - Microsoft will provide forward-looking guidance in connection with this quarterly earnings announcement on its earnings conference call and webcast. Quarterly Highlights, Product Releases , and Enhancements",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft Home page",
+        "url": "https://www.microsoft.com/en-us/investor/default",
+        "snippet": "16 hours ago - Press Release Webcast · August 27, 2025 · Email · July 28, 2025 · View Blog · Expand All | Collapse All · The next earnings release will be announced soon. Get the quarterly dividend amount, record date, ex-dividend date, payable date and history · Get Details ·",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Stock Titan Microsoft earnings press release available on Investor Relations website | MSFT Stock News",
+        "url": "https://www.stocktitan.net/news/MSFT/microsoft-earnings-press-release-available-on-investor-relations-myfiiryqytni.html",
+        "snippet": "January 30, 2024 - 30, 2024/ PRNewswire/-- Microsoft Corp. on Tuesday announced that fiscal year 2024 second-quarter financial results are available on its Investor Relations website. The direct link to the earnings press release is https://www.microsoft.com/en-us/Investor/earnings/FY-2024-Q2/press-release-webcast . ...",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft Home Page - Microsoft Investor Relations",
+        "url": "https://www.microsoft.com/en-us/investor",
+        "snippet": "July 31, 2024 - Press Release Webcast · August 27, 2025 · Email · July 28, 2025 · View Blog · Expand All | Collapse All · The next earnings release will be announced soon. Get the quarterly dividend amount, record date, ex-dividend date, payable date and history · Get Details ·",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Yahoo! Finance Microsoft Corporation (MSFT) Latest Press Releases & Corporate News - Yahoo Finance",
+        "url": "https://finance.yahoo.com/quote/MSFT/press-releases/",
+        "snippet": "2 weeks ago - Get the latest Microsoft Corporation (MSFT) stock news and headlines to help you in your trading and investing decisions.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft FY23 Q4 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/Investor/earnings/FY-2023-Q4/press-release-webcast",
+        "snippet": "July 25, 2023 - Microsoft will provide forward-looking guidance in connection with this quarterly earnings announcement on its earnings conference call and webcast. Quarterly Highlights, Product Releases , and Enhancements",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Nasdaq Microsoft Corporation (MSFT) Earnings Report Dates & Earnings Forecasts | Nasdaq",
+        "url": "https://www.nasdaq.com/market-activity/stocks/msft/earnings",
+        "snippet": "2 weeks ago - Find annual and quearterly earnings data for Microsoft Corporation Common Stock (MSFT) including earnings per share, earnings forecasts at Nasdaq.com.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft FY24 Q3 - Press Releases - Investor Relations - Microsoft",
+        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2024-q3/press-release-webcast",
+        "snippet": "Microsoft has provided this non-GAAP financial information to aid investors in better understanding our performance . The non-GAAP financial measures presented in this release should not be considered as a substitute for, or superior to, the measures of financial performance prepared in accordance ...",
         "content": null,
         "source": "ddg",
         "published_at": null
@@ -491,81 +491,121 @@
     ],
     "industry_reports": [
       {
-        "title": "Microsoft (MSFT) - Market capitalization",
-        "url": "https://companiesmarketcap.com/microsoft/marketcap/",
-        "snippet": "As of September 2025 Microsoft has a market cap of $3.704 Trillion USD. This makes Microsoft the world's 2nd most valuable company by market cap according to our data.",
+        "title": "Wikipedia Usage share of operating systems - Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Usage_share_of_operating_systems",
+        "snippet": "1 week ago - For smartphones and other mobile devices, Android has 72% market share, and Apple's iOS has 28%. For desktop computers and laptops, Microsoft Windows has 71% , followed by Apple's macOS at 16%, unknown operating systems at 8%, desktop Linux at 4%, then Google's ChromeOS at 2%.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Corporation (MSFT) Stock Price, Quote, News... | Nasdaq",
-        "url": "https://www.nasdaq.com/market-activity/stocks/msft",
-        "snippet": "Discover real-time Microsoft Corporation Common Stock (MSFT) stock prices, quotes, historical data, news, and Insights for informed trading and investment decisions.",
+        "title": "Statista Microsoft - statistics & facts | Statista",
+        "url": "https://www.statista.com/topics/823/microsoft/",
+        "snippet": "This move, powered by innovative tools like ChatGPT and Copilot, further cements its position as a tech titan with a rich history and ambitious plans. Notably, Microsoft has surpassed Apple in market capitalization as a tech giant in 2024 , showcasing its ongoing pursuit of dominance.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Corporation (MSFT) Stock Price, News... - Yahoo Finance",
-        "url": "https://finance.yahoo.com/quote/MSFT/",
-        "snippet": "Find the latest Microsoft Corporation (MSFT) stock quote, history, news and other vital information to help you with your stock trading and investing.",
+        "title": "SignHouse Microsoft Revenue and Growth Statistics (2024) - SignHouse",
+        "url": "https://usesignhouse.com/blog/microsoft-stats/",
+        "snippet": "August 1, 2024 - Some amazing facts about Microsoft Microsoft is a top tech company with a 21% market share worldwide . In April 2023, Microsoft’s market cap reached $2.254 trillion, showing its industry dominance. In FY2022, Microsoft was valued at $1.7 trillion, a 29.10% drop from its peak of $2.4 trillion ...",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft 2023 Annual Report",
-        "url": "https://www.microsoft.com/investor/reports/ar23/index.html",
-        "snippet": "Shares of our common stock may be purchased by employees at three-month intervals at 90% of the fair market value on the last trading day of each three-month period. Employees may purchase shares having a value not exceeding 15% of their gross compensation during an offering period.",
+        "title": "Microsoft 2024 Annual Report",
+        "url": "https://www.microsoft.com/investor/reports/ar24/?msockid=0b29fdf7f1d866c11c33eb9ef0106753",
+        "snippet": "Jun 23, 2025 · Fiscal year 2024 was a pivotal year for Microsoft. We entered our 50th year as a company and the second year of the AI platform shift. With these milestones, I’ve found myself …",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft Statistics 2023: Insights And Trends Explored",
-        "url": "https://www.newvisiontheatres.com/microsoft-statistics",
-        "snippet": "microsoft share market value. There are over 232 million Edge users worldwide and 5.4 billion Internet users. Around 600 million people have used Microsoft Edge at least once. Microsoft Bing is the second most used global search engine.",
+        "title": "Microsoft Market share relative to its competitors, as of Q2 ...",
+        "url": "https://csimarket.com/stocks/competitionSEG2.php?code=MSFT",
+        "snippet": "5 days ago · Microsoft's Q2 2025 quarter and 12 months market share, relative to the MSFT's competitors. Based on total revenues.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Market share for mobile, browsers, operating... | NetMarketShare",
-        "url": "https://netmarketshare.com/",
-        "snippet": "Mobile market share and desktop market share data.This journey began with reporting on the browser wars, and was one of the most fascinating and fun products anyone could hope to work on. All the best, The NetMarketshare Team.",
+        "title": "Cloud Market Share Q1 2025: AWS Dips, Microsoft And Google ...",
+        "url": "https://www.crn.com/news/cloud/2025/cloud-market-share-q1-2025-aws-dips-microsoft-and-google-show-growth",
+        "snippet": "May 8, 2025 · Microsoft’s global cloud market share has fluctuated between 20 percent share and 25 percent share for the past several years.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Browser Market Share 2025 (Popularity & Usage Statistics)",
-        "url": "https://www.yaguara.co/browser-market-share/",
-        "snippet": "Find out which browsers dominate in 2025. Full usage stats by OS, region, and popularity, with a complete breakdown of browser market share .",
+        "title": "MSFT: Microsoft - Full Company Report - Zacks.com",
+        "url": "https://www.zacks.com/stock/research/MSFT/company-reports",
+        "snippet": "6 days ago · Microsoft Corporation is one of the largest broad-based technology providers in the world. The company dominates the PC software market with more than 73% of the market …",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Battle for Top CRM Salesforce CRM vs Microsoft CRM",
-        "url": "https://www.linkedin.com/pulse/battle-top-crm-salesforce-vs-microsoft-sowmiyanarayanan-srinivasan-3mkwe",
-        "snippet": "Market Leader: Salesforce dominates the CRM market with a 23.2% market share as of 2023 according to IDC. It is known for its comprehensive CRM platform that includes sales, marketing , customer service, and analytics tools.",
+        "title": "Microsoft Statistics (2025): Growth, Revenue, and Market Cap",
+        "url": "https://www.skillademia.com/statistics/microsoft-statistics/",
+        "snippet": "Apr 7, 2025 · Discover the latest Microsoft statistics, revealing insights into its operational prowess, market dominance, and strategic moves.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft reminds of Windows 10 support ending in 30 days",
-        "url": "https://www.bleepingcomputer.com/news/microsoft/microsoft-reminds-of-windows-10-support-ending-in-30-days/",
-        "snippet": "Microsoft to force install the Microsoft 365 Copilot app in October. Microsoft says Windows September updates break SMBv1 shares .",
+        "title": "6sense Microsoft - Market Share, Competitor Insights in Applications Suite",
+        "url": "https://www.6sense.com/tech/applications-suite/microsoft-market-share",
+        "snippet": "Microsoft has market share of 9.62% in applications-suite market. Microsoft competes with 89 competitor tools in applications-suite category.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "2025's CMS Market Share Report - Latest Trends and Usage Stats",
-        "url": "https://www.wpbeginner.com/research/cms-market-share-report-latest-trends-and-usage-stats/",
-        "snippet": "We’ve divided our CMS market share and market size report into several different categories. Simply use the table of contents below to jump straight to the statistics or content management system you’re most interested in: CMS Usage Statistics.",
+        "title": "HG Insights Microsoft Azure Market Share & Buyer Landscape Report",
+        "url": "https://hginsights.com/blog/microsoft-azure-market-share-report",
+        "snippet": "February 11, 2025 - Microsoft Azure market share reached 24% of the global cloud market in 2024 . Discover insights into the Azure ecosystem and how it compares to AWS and GCP.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft 2024 Annual Report",
+        "url": "https://www.microsoft.com/investor/reports/ar24/?msockid=0b29fdf7f1d866c11c33eb9ef0106753",
+        "snippet": "Jun 23, 2025 · Fiscal year 2024 was a pivotal year for Microsoft. We entered our 50th year as a company and the second year of the AI platform shift. With these milestones, I’ve found myself …",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft Industry Clouds",
+        "url": "https://www.microsoft.com/en-us/industry?msockid=0b29fdf7f1d866c11c33eb9ef0106753",
+        "snippet": "Accelerate digital transformation with industry solutions built on the Microsoft Cloud.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft 2025 annual Work Trend Index",
+        "url": "https://news.microsoft.com/annual-work-trend-index-2025/?msockid=0b29fdf7f1d866c11c33eb9ef0106753",
+        "snippet": "Today’s work is pushing the limits of humans alone, keeping employees from high-value tasks that drive growth and innovation. The Microsoft 365 Copilot app is designed to enable people and …",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "What's Next for Industry - news. microsoft .com",
+        "url": "https://news.microsoft.com/industry/?msockid=0b29fdf7f1d866c11c33eb9ef0106753",
+        "snippet": "We’re announcing another milestone in our efforts to support and co-innovate with customers and partners with the announcement of three new industry-specific solutions: Microsoft Cloud for …",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Microsoft - statistics & facts | Statista",
+        "url": "https://www.statista.com/topics/823/microsoft/",
+        "snippet": "Mar 7, 2025 · Research expert covering cloud computing and emerging tech industries. Find the latest statistics on Microsoft, one of the largest cloud and computer software providers in the …",
         "content": null,
         "source": "ddg",
         "published_at": null
@@ -587,17 +627,17 @@
         "published_at": null
       },
       {
-        "title": "Microsoft | MSFT Stock Price, Company Overview & News",
-        "url": "https://www.forbes.com/companies/microsoft/",
-        "snippet": "Microsoft Corp. engages in the development and support of software, services, devices, and solutions. It operates through the following business segments:",
+        "title": "Industry trends Archives - Microsoft in Business Blogs",
+        "url": "https://www.microsoft.com/en-us/industry/microsoft-in-business/content-type/industry-trends/",
+        "snippet": "The Microsoft AI in Education report reveals that 47% of leaders in education use AI daily. However, a gap in AI literacy is emerging. A woman holding a ...",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Industry trends Archives - Microsoft in Business Blogs",
-        "url": "https://www.microsoft.com/en-us/industry/microsoft-in-business/content-type/industry-trends/",
-        "snippet": "The Microsoft AI in Education report reveals that 47% of leaders in education use AI daily. However, a gap in AI literacy is emerging. A woman holding a ...",
+        "title": "Microsoft | MSFT Stock Price, Company Overview & News",
+        "url": "https://www.forbes.com/companies/microsoft/",
+        "snippet": "Microsoft Corp. engages in the development and support of software, services, devices, and solutions. It operates through the following business segments:",
         "content": null,
         "source": "ddg",
         "published_at": null
@@ -611,121 +651,81 @@
         "published_at": null
       },
       {
-        "title": "Microsoft Corporation (MSFT) Company Profile & Facts",
-        "url": "https://finance.yahoo.com/quote/MSFT/profile/",
-        "snippet": "See the company profile for Microsoft Corporation (MSFT) including business summary, industry/sector information , number of employees, business summary, ...",
+        "title": "Microsoft Competitors Analysis : Top 5 ... - Business Chronicler",
+        "url": "https://businesschronicler.com/competitors/microsoft-competitors-analysis/",
+        "snippet": "Learn how Microsoft competes with Google, Amazon, Apple, Salesforce, and IBM in various markets such as cloud computing, enterprise solutions, and gaming. Compare their strengths, weaknesses, opportunities, and threats based on SWOT analysis.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Microsoft industry documentation and resources",
-        "url": "https://learn.microsoft.com/en-us/industry/",
-        "snippet": "This documentation includes information about the Microsoft Clouds for Healthcare, Financial Services, Retail, Manufacturing, Nonprofit, Sovereignty, and ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Research for Industry",
-        "url": "https://www.microsoft.com/en-us/research/group/research-for-industry/",
-        "snippet": "The Research for Industry (RFI) initiative seeks to identify and accelerate scientific advances in technologies such as data platforms, connectivity, robotics, ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Microsoft 2024 Annual Report",
-        "url": "https://www.microsoft.com/investor/reports/ar24/index.html",
-        "snippet": "We delivered over $245 billion in annual revenue , up 16 percent year-over-year, and over $109 billion in operating income, up 24 percent.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "FY25 Q4 - Press Releases - Investor Relations",
-        "url": "https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast",
-        "snippet": "Jul 30, 2025 — Here are the major product releases and other highlights for the quarter , organized by product categories, to help illustrate how we are ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "CSIMarket Microsoft Corporation Comparisons to its Competitors and Market Share - CSIMarket",
-        "url": "https://csimarket.com/stocks/compet_glance.php?code=MSFT",
-        "snippet": "Microsoft comparisons to its competitors , by sales, income, profitability, market share by products and services - CSIMarket",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Owler Microsoft’s Competitors, Revenue, Number of Employees, Funding, Acquisitions & News - Owler Company Profile",
-        "url": "https://www.owler.com/company/microsoft",
-        "snippet": "Microsoft’s Profile, Revenue and Employees. Microsoft is a Washington-based multinational technology company that develops, licenses, and sells computers, software apps, gaming, and cloud computing products. Microsoft’s primary competitors include IBM, Google, Oracle and 28 more.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Investopedia Who are Microsoft's (MSFT) Main Competitors?",
-        "url": "https://www.investopedia.com/ask/answers/120314/who-are-microsofts-msft-main-competitors.asp",
-        "snippet": "July 30, 2021 - Gordon Scott has been an active investor and technical analyst or 20+ years. He is a Chartered Market Technician (CMT). ... Pete Rathburn is a copy editor and fact-checker with expertise in economics and personal finance and over twenty years of experience in the classroom. ... Microsoft Corporation’s (MSFT) primary competitors ...",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Quartz Thirty years of financial filings reveal Microsoft’s biggest competitors",
-        "url": "https://qz.com/1553700/this-30-year-timeline-reveals-microsofts-biggest-competitors",
-        "snippet": "July 21, 2022 - It had just launched Windows, and ... neatly summarized its competitors in two categories: computer software makers (notably IBM, AT&T and Apple) and independent systems software vendors, such as Digital Research and AT&T ....",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Craft Top Microsoft Competitors and Alternatives | Craft.co",
-        "url": "https://craft.co/microsoft/competitors",
-        "snippet": "Microsoft's main competitors include Oracle, Dell, Salesforce, Zoom, Slack, Meta, Sony Group, Hewlett Packard Enterprise, Apple, Google and IBM . Compare Microsoft to its competitors by revenue, employee growth and other metrics at Craft.",
-        "content": null,
-        "source": "ddg",
-        "published_at": null
-      },
-      {
-        "title": "Business Model Analyst Top 15 Microsoft Competitors & Alternatives (2025)",
+        "title": "Top 15 Microsoft Competitors & Alternatives (2025)",
         "url": "https://businessmodelanalyst.com/microsoft-competitors/",
-        "snippet": "October 31, 2024 - This article will explore the top 15 Microsoft competitors and alternatives across different sectors.",
+        "snippet": "Aug 1, 2024 · This article will explore the top 15 Microsoft competitors and alternatives across different sectors.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "CanvasBusinessModel What is Competitive Landscape of Microsoft Company? – CanvasBusinessModel.com",
-        "url": "https://canvasbusinessmodel.com/blogs/competitors/microsoft-competitive-landscape",
-        "snippet": "July 12, 2025 - Microsoft competitors are constantly innovating and expanding their offerings, putting pressure on Microsoft to maintain its position. This dynamic environment necessitates continuous adaptation and strategic moves to stay ahead. A detailed tech industry analysis reveals the complexities of ...",
+        "title": "Who are Microsoft's (MSFT) Main Competitors? - Investopedia Microsoft Competitor Analysis - The Strategy Story Competitor Analysis: Evaluating Microsoft And Competitors In ... Top 15 Microsoft Competitors & Alternatives (2025) Who Are Microsoft's Competitors: An In-Depth Analysis Microsoft Competitor Analysis - The Strategy Story How Microsoft ’s Business Compares with its Competitors Top 15 Microsoft Competitors & Alternatives (2025) Microsoft Competitors Analysis - Business Chronicler Microsoft Competitors Analysis - Business Chronicler How Microsoft ’s Business Compares with its Competitors How Microsoft’s Business Compares with its Competitors",
+        "url": "https://www.investopedia.com/ask/answers/120314/who-are-microsofts-msft-main-competitors.asp",
+        "snippet": "Learn the main competitors of technology giant Microsoft and the stiff competition facing in this industry leader. Learn how Microsoft competes with various companies in different domains, such as operating systems, software, cloud computing, and hardware. Explore its strategies, strengths, weaknesses, and opportunities in the competitive landscape. Sep 2, 2025 · Key Takeaways For Microsoft in the Software industry, the PE and PB ratios suggest the company is undervalued compared to its peers, indicating potential for growth. Aug 1, 2024 · This article will explore the top 15 Microsoft competitors and alternatives across different sectors. Jul 9, 2025 · Who are Microsoft ' s competitors in the ever-evolving tech industry? This article provides a thorough analysis of the major players vying for dominance against Microsoft across various sectors, including software, cloud computing, and gaming. What is Microsoft competitor analysis? Before we get into the specifics of Microsoft, let’s understand competitor analysis. Competitor analysis is a strategic research method companies use to identify, evaluate, and understand their current and potential competitors within the market. It’s an essential business strategy component and instrumental in understanding the industry landscape. How does Microsoft measure up against its competitors? This analysis delves into how Microsoft measures up against its key competitors, examining critical areas such as market position, product offerings, financial performance, and strategic initiatives . Understanding Microsoft’s market position is vital for a comprehensive view of its competitive strengths and weaknesses. What are the top 15 Microsoft competitors and alternatives? This article will explore the top 15 Microsoft competitors and alternatives across different sectors. Companies like Apple Inc., Google (Alphabet Inc.), Dell Technologies, HP Inc., and Lenovo provide robust alternatives to Microsoft ’s operating systems and hardware offerings. How does Microsoft compete with other companies? Microsoft competes against Apple, Amazon, Salesforce, IBM, and Google in multiple markets . These players are developing their presence in various verticals to provide a comprehensive range of products and services. Does Microsoft face competition? Competition: Microsoft faces competition from Google, Amazon, Apple (players who could represent threats) in this segment. Moreover, the existence of fierce rivals opens avenues for the potential entry of new players that may impact revenue generation and market share. How does Microsoft's market dominance affect competitors? Its market dominance not only solidifies consumer trust but also creates barriers for new entrants, making it difficult for competitors to gain significant ground . Competitive Landscape: Microsoft’s major competitors include Apple, Google, Amazon, and IBM. Each of these companies challenges Microsoft in various domains: Aug 6, 2024 · This analysis delves into how Microsoft measures up against its key competitors , examining critical areas such as market position, product offerings, financial performance, and strategic initiatives.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Nasdaq Comparative Study: Microsoft And Industry Competitors In Software Industry | Nasdaq",
-        "url": "https://www.nasdaq.com/articles/comparative-study-microsoft-and-industry-competitors-software-industry",
-        "snippet": "September 16, 2024 - For Microsoft in the Software industry, the PE ratio is low compared to peers, indicating potential undervaluation . The PB ratio is also low, suggesting a possible bargain opportunity. However, the PS ratio is high, signaling rich valuation based on revenue. In terms of ROE, Microsoft shows ...",
+        "title": "Microsoft Competitor Analysis - The Strategy Story",
+        "url": "https://thestrategystory.com/blog/microsoft-competitor-analysis/",
+        "snippet": "Learn how Microsoft competes with various companies in different domains, such as operating systems, software, cloud computing, and hardware. Explore its strategies, strengths, weaknesses, and opportunities in the competitive landscape.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Comparably Microsoft Competitors | Comparably",
-        "url": "https://www.comparably.com/companies/microsoft/competitors",
-        "snippet": "Microsoft competitors include Google, Apple, Sony, and Yahoo .",
+        "title": "Competitor Analysis: Evaluating Microsoft And Competitors In ...",
+        "url": "https://www.benzinga.com/insights/news/25/09/47451965/competitor-analysis-evaluating-microsoft-and-competitors-in-software-industry",
+        "snippet": "Sep 2, 2025 · Key Takeaways For Microsoft in the Software industry, the PE and PB ratios suggest the company is undervalued compared to its peers, indicating potential for growth.",
         "content": null,
         "source": "ddg",
         "published_at": null
       },
       {
-        "title": "Ask.com Microsoft vs. Competitors: How the Tech Giant Stays Ahead in the Industry - Ask.com",
-        "url": "https://www.ask.com/news/microsoft-vs-competitors-tech-giant-stays-ahead-industry",
-        "snippet": "May 21, 2025 - One of the key factors that have kept Microsoft ahead of its competitors is its commitment to continuous innovation . The tech giant has a long history of introducing groundbreaking products and services that have revolutionized various industries.",
+        "title": "Who Are Microsoft's Competitors: An In-Depth Analysis",
+        "url": "https://pocketoption.com/blog/en/interesting/reviews/who-are-microsoft-s-competitors/",
+        "snippet": "Jul 9, 2025 · Who are Microsoft ' s competitors in the ever-evolving tech industry? This article provides a thorough analysis of the major players vying for dominance against Microsoft across various sectors, including software, cloud computing, and gaming.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "How Microsoft’s Business Compares with its Competitors",
+        "url": "https://blog.disfold.com/microsoft-compares-competitors/",
+        "snippet": "Aug 6, 2024 · This analysis delves into how Microsoft measures up against its key competitors , examining critical areas such as market position, product offerings, financial performance, and strategic initiatives.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Top Microsoft Competitors and Alternatives | Craft.co",
+        "url": "https://craft.co/microsoft/competitors",
+        "snippet": "Microsoft 's competitors and similar companies include Oracle, Dell, Salesforce, Zoom, Slack, Meta, Sony Group, Hewlett Packard Enterprise, Apple, Google and IBM.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Top 26 Microsoft Alternatives & Competitors in 2025",
+        "url": "https://www.marketing91.com/microsoft-competitors-alternatives/",
+        "snippet": "Brands Analysis . Microsoft is a technology company founded in 1975 by Bill Gates and Paul Allen to develop and sell BASIC interpreters for the Altair 8800.",
+        "content": null,
+        "source": "ddg",
+        "published_at": null
+      },
+      {
+        "title": "Top 15 Microsoft Competitors & Alternatives | Business Strategy Hub",
+        "url": "https://bstrategyhub.com/microsoft-competitors-alternatives/",
+        "snippet": "Here is an in-depth analysis of Microsoft ’s top 15 competitors and alternatives: Table of Contents. Toggle. Microsoft competes with several companies in three segments",
         "content": null,
         "source": "ddg",
         "published_at": null
@@ -733,29 +733,29 @@
     ],
     "competitors": [
       "Top 15 Microsoft Competitors & Alternatives (2025)",
-      "While Microsoft has dominated many markets",
-      "competitors",
-      "Comparably Microsoft Competitors   Comparably",
-      "Microsoft competitors include Google",
-      "Apple",
-      "Sony",
-      "and Yahoo.",
-      "Marketing91 Top 26 Microsoft Alternatives & Competitors in 2025",
-      "November 28",
-      "2024 - The top Microsoft competitors are Google (Alphabet Inc.)",
+      "Aug 1",
+      "whether in cloud computing",
+      "productivity …",
+      "Top 26 Microsoft Competitors & Alternatives in 2025",
+      "Nov 28",
+      "2024 · The top Microsoft competitors are Google (Alphabet Inc.)",
       "Amazon (Amazon Web Services)",
       "Apple Inc.",
       "Oracle",
-      "IBM (Including Red Hat)"
+      "IBM (Including Red Hat)",
+      "Salesforce",
+      "Adobe and others.",
+      "Top Microsoft Competitors and Alternatives   Craft.co",
+      "Microsoft 's main competitors include Oracle"
     ]
   },
   "summary": {
     "executive_brief": "Microsoft overview based on public signals.\n\n- Recent press suggests momentum in launches or partnerships.\n- Earnings disclosures indicate budget focus and near-term priorities.\n- Industry coverage frames their market position and threats.\n- Competitor set informs differentiation in the conversation.",
-    "ads_opportunities": "Map messaging to current announcements and owned moments. Use LinkedIn for awareness among professional audiences and precise retargeting of high-intent segments.\n\nTop sources:\n- How to write a captivating press release with AI\n- FY24 Q3 - Press Releases - Investor Relations\n- FY23 Q2 - Press Releases - Investor Relations\n- FY25 Q4 - Press Releases - Investor Relations\n- FY23 Q3 - Press Releases - Investor Relations\n- Microsoft (MSFT) - Market capitalization\n- Microsoft Corporation (MSFT) Stock Price, Quote, News... | Nasdaq\n- Microsoft Corporation (MSFT) Stock Price, News... - Yahoo Finance\n- Microsoft 2023 Annual Report\n- Microsoft Statistics 2023: Insights And Trends Explored",
+    "ads_opportunities": "Map messaging to current announcements and owned moments. Use LinkedIn for awareness among professional audiences and precise retargeting of high-intent segments.\n\nTop sources:\n- How to write a captivating press release with AI\n- FY24 Q3 - Press Releases - Investor Relations\n- FY25 Q4 - Press Releases - Investor Relations\n- FY23 Q2 - Press Releases - Investor Relations\n- FY23 Q3 - Press Releases - Investor Relations\n- Wikipedia Usage share of operating systems - Wikipedia\n- Statista Microsoft - statistics & facts | Statista\n- SignHouse Microsoft Revenue and Growth Statistics (2024) - SignHouse\n- Microsoft 2024 Annual Report\n- Microsoft Market share relative to its competitors, as of Q2 ...",
     "recruiting_notes": "Connect hiring needs to strategic initiatives surfaced in press and earnings. Use LinkedIn Talent solutions to reach niche talent pools tied to those bets.",
     "risks_flags": "Watch for restructuring, regulatory items, or guidance changes in earnings. Avoid referencing speculative or unconfirmed negative press.",
-    "renewal_prep": "Goals: confirm value realized, map to current priorities, propose next-step pilots.\n\n- Tie outcomes to last 2–3 public signals (press/earnings).\n- Identify 1–2 expansion plays (new LOB, geo, or audience).\n- Prepare proof points (reach in ICP roles, CTR/lead quality, talent pipeline).\n\nRecent signals:\n- How to write a captivating press release with AI\n- FY24 Q3 - Press Releases - Investor Relations\n- FY23 Q2 - Press Releases - Investor Relations\n- Media Alert: Martin Taylor Webcast for Microsoft Investor Relations ...\n- Microsoft announces quarterly dividend increase",
-    "outbound_prep": "Goals: establish relevance quickly, align to a timely initiative, propose a low-lift pilot.\n\n- Open with a reference to a fresh press item or earnings priority.\n- Position LinkedIn as the most trusted professional reach plus closed-loop impact.\n- Offer a test (ABM for launch audiences, demand for key product line, or talent spotlight).\n\nConversation anchors:\n- Microsoft (MSFT) - Market capitalization\n- Microsoft Corporation (MSFT) Stock Price, Quote, News... | Nasdaq\n- Microsoft Corporation (MSFT) Stock Price, News... - Yahoo Finance",
+    "renewal_prep": "Goals: confirm value realized, map to current priorities, propose next-step pilots.\n\n- Tie outcomes to last 2–3 public signals (press/earnings).\n- Identify 1–2 expansion plays (new LOB, geo, or audience).\n- Prepare proof points (reach in ICP roles, CTR/lead quality, talent pipeline).\n\nRecent signals:\n- How to write a captivating press release with AI\n- FY24 Q3 - Press Releases - Investor Relations\n- FY25 Q4 - Press Releases - Investor Relations\n- Information for Investors\n- Investor Relations",
+    "outbound_prep": "Goals: establish relevance quickly, align to a timely initiative, propose a low-lift pilot.\n\n- Open with a reference to a fresh press item or earnings priority.\n- Position LinkedIn as the most trusted professional reach plus closed-loop impact.\n- Offer a test (ABM for launch audiences, demand for key product line, or talent spotlight).\n\nConversation anchors:\n- Wikipedia Usage share of operating systems - Wikipedia\n- Statista Microsoft - statistics & facts | Statista\n- SignHouse Microsoft Revenue and Growth Statistics (2024) - SignHouse",
     "lob_value_props": {
       "Marketing": "LinkedIn Marketing Solutions: tools for B2B marketers to build awareness, generate leads, and run targeted campaigns.\n\n- Sponsored Content and ad formats (single image, video, carousel, document)\n- Sponsored Messaging (Message Ads, Conversation Ads) for direct engagement\n- Dynamic Ads and Text Ads for personalized reach\n- Lead Gen Forms with CRM/automation integrations",
       "Sales": "LinkedIn Sales Solutions: help sales teams find, engage, prioritize, and convert prospects.\n\n- Sales Navigator for advanced prospecting and buying-committee visibility\n- Deep Sales (next-gen Navigator) with AI-driven insights and buyer intent\n- Sales Insights for operations: market sizing, account potential, and trends",
@@ -767,9 +767,7 @@
     "pitch_headlines": [
       "Press: [How to write a captivating press release with AI](https://www.microsoft.com/en-us/microsoft-365-life-hacks/everyday-ai/write-a-press-release-with-ai)",
       "Press: [FY24 Q3 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2024-q3/press-release-webcast)",
-      "Press: [FY23 Q2 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2023-q2/press-release-webcast)",
-      "Earnings/IR: [Media Alert: Martin Taylor Webcast for Microsoft Investor Relations ...](https://news.microsoft.com/2004/02/25/media-alert-martin-taylor-webcast-for-microsoft-investor-relations/)",
-      "Earnings/IR: [Microsoft announces quarterly dividend increase](https://news.microsoft.com/source/2025/09/15/microsoft-announces-quarterly-dividend-increase-6/)"
+      "Press: [FY25 Q4 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast)"
     ]
   }
 }

--- a/microsoft_report.md
+++ b/microsoft_report.md
@@ -5,9 +5,7 @@ Website: https://www.microsoft.com/
 ## Top Headlines to Mention
 - Press: [How to write a captivating press release with AI](https://www.microsoft.com/en-us/microsoft-365-life-hacks/everyday-ai/write-a-press-release-with-ai)
 - Press: [FY24 Q3 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2024-q3/press-release-webcast)
-- Press: [FY23 Q2 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2023-q2/press-release-webcast)
-- Earnings/IR: [Media Alert: Martin Taylor Webcast for Microsoft Investor Relations ...](https://news.microsoft.com/2004/02/25/media-alert-martin-taylor-webcast-for-microsoft-investor-relations/)
-- Earnings/IR: [Microsoft announces quarterly dividend increase](https://news.microsoft.com/source/2025/09/15/microsoft-announces-quarterly-dividend-increase-6/)
+- Press: [FY25 Q4 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast)
 
 ## Selected Line of Business Focus
 LTS: LinkedIn Talent Solutions helps organizations attract, engage, and hire the right talent by leveraging LinkedIn’s professional network and data.
@@ -37,9 +35,9 @@ Goals: confirm value realized, map to current priorities, propose next-step pilo
 Recent signals:
 - How to write a captivating press release with AI
 - FY24 Q3 - Press Releases - Investor Relations
-- FY23 Q2 - Press Releases - Investor Relations
-- Media Alert: Martin Taylor Webcast for Microsoft Investor Relations ...
-- Microsoft announces quarterly dividend increase
+- FY25 Q4 - Press Releases - Investor Relations
+- Information for Investors
+- Investor Relations
 
 ## Outbound Prospecting Prep
 Goals: establish relevance quickly, align to a timely initiative, propose a low-lift pilot.
@@ -49,9 +47,9 @@ Goals: establish relevance quickly, align to a timely initiative, propose a low-
 - Offer a test (ABM for launch audiences, demand for key product line, or talent spotlight).
 
 Conversation anchors:
-- Microsoft (MSFT) - Market capitalization
-- Microsoft Corporation (MSFT) Stock Price, Quote, News... | Nasdaq
-- Microsoft Corporation (MSFT) Stock Price, News... - Yahoo Finance
+- Wikipedia Usage share of operating systems - Wikipedia
+- Statista Microsoft - statistics & facts | Statista
+- SignHouse Microsoft Revenue and Growth Statistics (2024) - SignHouse
 
 ## LinkedIn Value Props (Selected LOB)
 LinkedIn Talent Solutions helps organizations attract, engage, and hire the right talent by leveraging LinkedIn’s professional network and data.
@@ -69,14 +67,14 @@ Map messaging to current announcements and owned moments. Use LinkedIn for aware
 Top sources:
 - How to write a captivating press release with AI
 - FY24 Q3 - Press Releases - Investor Relations
-- FY23 Q2 - Press Releases - Investor Relations
 - FY25 Q4 - Press Releases - Investor Relations
+- FY23 Q2 - Press Releases - Investor Relations
 - FY23 Q3 - Press Releases - Investor Relations
-- Microsoft (MSFT) - Market capitalization
-- Microsoft Corporation (MSFT) Stock Price, Quote, News... | Nasdaq
-- Microsoft Corporation (MSFT) Stock Price, News... - Yahoo Finance
-- Microsoft 2023 Annual Report
-- Microsoft Statistics 2023: Insights And Trends Explored
+- Wikipedia Usage share of operating systems - Wikipedia
+- Statista Microsoft - statistics & facts | Statista
+- SignHouse Microsoft Revenue and Growth Statistics (2024) - SignHouse
+- Microsoft 2024 Annual Report
+- Microsoft Market share relative to its competitors, as of Q2 ...
 
 ## Recruiting Notes
 Connect hiring needs to strategic initiatives surfaced in press and earnings. Use LinkedIn Talent solutions to reach niche talent pools tied to those bets.
@@ -87,8 +85,8 @@ Watch for restructuring, regulatory items, or guidance changes in earnings. Avoi
 ## Press Releases & Newsroom
 - [How to write a captivating press release with AI](https://www.microsoft.com/en-us/microsoft-365-life-hacks/everyday-ai/write-a-press-release-with-ai) — Mar 24, 2025 — Get the coverage you deserve with tips on how to write a press release . Use AI to craft a compelling headline, draft a press release outline ...
 - [FY24 Q3 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2024-q3/press-release-webcast) — Earnings Release FY24 Q3 · Revenue was $61.9 billion and increased 17% · Operating income was $27.6 billion and increased 23% · Net income was $21.9 billion and ...
-- [FY23 Q2 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2023-q2/press-release-webcast) — Microsoft returned $9.7 billion to shareholders in the form of share repurchases and dividends in the second quarter of fiscal year 2023, a decrease of 11% ...
 - [FY25 Q4 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/press-release-webcast) — Jul 30, 2025 — Earnings Release FY25 Q4 · Revenue was $76.4 billion and increased 18% (up 17% in constant currency) · Operating income was $34.3 billion and ...
+- [FY23 Q2 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2023-q2/press-release-webcast) — Microsoft returned $9.7 billion to shareholders in the form of share repurchases and dividends in the second quarter of fiscal year 2023, a decrease of 11% ...
 - [FY23 Q3 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2023-q3/press-release-webcast) — Earnings Release FY23 Q3 · Revenue was $52.9 billion and increased 7% (up 10% in constant currency) · Operating income was $22.4 billion and increased 10% (up ...
 - [FY22 Q2 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2022-q2/press-release-webcast) — Earnings Release FY22 Q2 · Revenue was $51.7 billion and increased 20% · Operating income was $22.2 billion and increased 24% · Net income was $18.8 billion and ...
 - [FY25 Q3 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q3/press-release-webcast) — Apr 30, 2025 — Microsoft Corp. today announced the following results for the quarter ended March 31, 2025 , as compared to the corresponding period of last fiscal year.
@@ -96,58 +94,58 @@ Watch for restructuring, regulatory items, or guidance changes in earnings. Avoi
 - [FY22 Q4 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2022-q4/press-release-webcast) — Microsoft Corp. today announced the following results for the quarter ended June 30, 2022 , as compared to the corresponding period of last fiscal year.
 - [FY25 Q1 - Press Releases - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/press-release-webcast) — Oct 30, 2024 — Microsoft Corp. today announced the following results for the quarter ended September 30, 2024, as compared to the corresponding period of last fiscal year.
 - [Journalism Hub - Tech Tools for Journalists | Microsoft CSR](https://www.microsoft.com/en-us/corporate-responsibility/journalism-hub) — Increase the efficiency and reach of the newsroom by leveraging apps, training videos, and tools that maximize your Microsoft 365 experience to improve your research, reporting, and reach to your community.
+- [Microsoft 365 News | Microsoft 365 Blog](https://www.microsoft.com/en-us/microsoft-365/blog/content-type/news/) — 4 days ago · Microsoft 365 Blog highlights the latest News to keep you in-the-know on Windows 11 and 365, Teams, Viva, and more.
+- [Pushing passkeys forward: Microsoft’s latest updates for ...](https://www.microsoft.com/en-us/security/blog/2025/05/01/pushing-passkeys-forward-microsofts-latest-updates-for-simpler-safer-sign-ins/) — May 1, 2025 · Join us in embracing passkeys for secure, passwordless sign-ins. Learn more about our commitment to a safer digital future.
+- [2024 Microsoft Pro Bono Report](https://www.microsoft.com/en-us/legal/diversity/pro-bono-programs/2024-pro-bono-report) — Legal assistance from volunteers with ProJourn strengthened the KNKX newsroom ’s confidence to publish a story that uncovered allegations of racial and sexual harassment and player endangerment by two youth league soccer coaches in Redmond, Washington.
 - [Democracy Forward - Protecting Democracy | Microsoft CSR](https://www.microsoft.com/en-us/corporate-responsibility/democracy-forward) — Microsoft is working to stem threats to democracy by helping to secure elections, protect voting rights, and support journalists through our Democracy Forward program.
-- [Microsoft AI Blogs | Artificial Intelligence News and Updates](https://www.microsoft.com/en-us/ai/blog/) — 6 days ago · Microsoft AI Blog keeps you up-to-date about the latest advancements in artificial intelligence and their integration into our products and platforms.
-- [Microsoft Research Lab - Redmond ...](https://www.microsoft.com/en-us/research/lab/microsoft-research-redmond/news-and-awards/?pg=54) — Computer science research supporting the future of the connected world with secure computing that enriches lives and empowers everyone.
-- [Microsoft 365 Copilot News and Insights](https://www.microsoft.com/en-us/microsoft-365/blog/product/microsoft-365-copilot/) — Learn how this AI-powered assistant enhances productivity by seamlessly integrating with your Microsoft 365 apps, documents, and conversations.
 
 ## Earnings & Investor Updates
-- [Media Alert: Martin Taylor Webcast for Microsoft Investor Relations ...](https://news.microsoft.com/2004/02/25/media-alert-martin-taylor-webcast-for-microsoft-investor-relations/) — Martin Taylor, General Manager, Platform Strategy. What: As part of an ongoing speaker series from the Investor Relations team, Taylor will discuss Microsofts competitive strategy efforts...
-- [Microsoft announces quarterly dividend increase](https://news.microsoft.com/source/2025/09/15/microsoft-announces-quarterly-dividend-increase-6/) — For more information, financial analysts and investors only: Jonathan Neilson, Vice President, Investor Relations , (425) 706-4400.
 - [Information for Investors](https://www.microsoft.com/en-us/investor/investor-information) — New Investor . If you want to know more about Microsoft, the following materials will help provide an introduction to our business.
 - [Investor Relations](https://www.microsoft.com/investor/reports/ar12/investor-relations/index.html) — You can contact Microsoft Investor Relations at any time to order financial documents such as annual reports and Form 10-Ks free of charge.
 - [Microsoft Investor Relations - Dividends and Stock History](https://www.microsoft.com/en-us/investor/dividends-and-stock-history) — Computershare, Microsoft's transfer agent, administers a direct stock purchase plan and a dividend reinvestment plan for the company. To find out more about ...
-- [Filter SEC Filings - Investor Relations](https://www.microsoft.com/en-us/investor/sec-filings) — Recent quarterly and annual filings are available from this web site in Microsoft Word format . Expanded and historical information is available from a third- ...
 - [Microsoft Investor Relations - Contact Information](https://www.microsoft.com/en-us/investor/contact-information) — Questions related to Microsoft finance or stock. E-mail: msft@microsoft.com. Phone: ( 800) 285-7772 (United States) (425) 706-4400 (International).
+- [Microsoft Investor Relations - SEC Filings](https://www.microsoft.com/en-us/investor/sec-filings) — Recent quarterly and annual filings are available from this web site in Microsoft Word format . Expanded and historical information is available from a third- ...
 - [Segment Information - Microsoft Investor Relations](https://www.microsoft.com/en-us/investor/segment-information) — Our Productivity and Business Processes segment consists of products and services in our portfolio of productivity, communication, and information services.
 - [Microsoft Investor Relations - Events](https://www.microsoft.com/en-us/investor/events/default) — Past Events · Microsoft Fiscal Year 2024 Second Quarter Earnings Conference Call · January 30, 2024 2:30 PM - PT · Microsoft Fiscal Year 2024 Second Quarter ...
 - [Investor Relations](https://www.microsoft.com/en-us/investor/default) — Get the quarterly dividend amount, record date, ex-dividend date, payable date and history. Get Details
-- [Earnings Release FY25 Q3 - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q3/performance) — Cost of revenue increased $3.4 billion or 18 % driven by growth in Microsoft Cloud. Gross margin increased $4.8 billion or 11% with growth across each of our ...
-- [Segment Revenue and Operating Income - FY25 Q1](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/segment-revenues) — Download Earnings Related Files · Earnings Call Slides · Earnings Call Transcript · Financial Statements · Outlook · Press Release · 10Q · FY25Q1 Product ...
-- [More Personal Computing Performance - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/more-personal-computing-performance) — More Personal Computing Revenue increased $1.9 billion or 17%. Windows and Devices revenue decreased slightly. Windows OEM and Devices revenue increased 2%.
-- [Microsoft FY25 Fourth Quarter Earnings Conference Call](https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4) — Jul 30, 2025 — We expect COGS of $24.3 to $24.5 billion or growth of 21% to 22% and operating expense of $15.7 to $15.8 billion or growth of 5% to 6%.
-- [Earnings Release FY25 Q2 - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q2/performance) — Performance. Revenue increased $7.6 billion or 12 % driven by growth in Intelligent Cloud and Productivity and Business Processes. Intelligent Cloud revenue ...
+- [Microsoft Investor Relations - Annual Reports](https://www.microsoft.com/en-us/investor/annual-reports) — Shareholders may opt for the convenience of electronic shareholder materials. Subscribers receive messages containing links to the online annual report and ...
+- [FY25 Q1 - Performance - Investor Relations](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/performance) — Performance. Revenue increased $9.1 billion or 16 % driven by growth across each of our segments. Intelligent Cloud revenue increased driven by Azure.
+- [Microsoft Home page](https://www.microsoft.com/en-us/investor/default) — The next earnings release will be announced soon.
+- [Microsoft Microsoft Fiscal Year 2025 Fourth Quarter Earnings Conference Call](https://www.microsoft.com/en-us/investor/events/fy-2025/earnings-fy-2025-q4) — On the Microsoft Investor Relations website, you can find our earnings press release and financial summary slide deck, which is intended to supplement our prepared remarks during today’s call and provides the reconciliation of differences between GAAP and non-GAAP financial measures.
+- [Microsoft FY25 Q1 - Segment Revenue and Operating Income - Investor Relations - Microsoft](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q1/segment-revenues) — Information contained in these documents is current as of the earnings date, and not restated for new accounting standards
+- [Microsoft FY25 Q4 - Cash Flows - Investor Relations - Microsoft](https://www.microsoft.com/en-us/Investor/earnings/FY-2025-Q4/cash-flows?msockid=2df94fec3e2b6c39381159883ff06dfa) — Information contained in these documents is current as of the earnings date, and not restated for new accounting standards
+- [Microsoft FY25 Q4 - More Personal Computing Performance - Investor Relations - Microsoft](https://www.microsoft.com/en-us/investor/earnings/fy-2025-q4/more-personal-computing-performance) — Information contained in these documents is current as of the earnings date, and not restated for new accounting standards
 
 ## Industry Reports & Coverage
-- [Microsoft (MSFT) - Market capitalization](https://companiesmarketcap.com/microsoft/marketcap/) — As of September 2025 Microsoft has a market cap of $3.704 Trillion USD. This makes Microsoft the world's 2nd most valuable company by market cap according to our data.
-- [Microsoft Corporation (MSFT) Stock Price, Quote, News... | Nasdaq](https://www.nasdaq.com/market-activity/stocks/msft) — Discover real-time Microsoft Corporation Common Stock (MSFT) stock prices, quotes, historical data, news, and Insights for informed trading and investment decisions.
-- [Microsoft Corporation (MSFT) Stock Price, News... - Yahoo Finance](https://finance.yahoo.com/quote/MSFT/) — Find the latest Microsoft Corporation (MSFT) stock quote, history, news and other vital information to help you with your stock trading and investing.
-- [Microsoft 2023 Annual Report](https://www.microsoft.com/investor/reports/ar23/index.html) — Shares of our common stock may be purchased by employees at three-month intervals at 90% of the fair market value on the last trading day of each three-month period. Employees may purchase shares having a value not exceeding 15% of their gross compensation during an offering period.
-- [Microsoft Statistics 2023: Insights And Trends Explored](https://www.newvisiontheatres.com/microsoft-statistics) — microsoft share market value. There are over 232 million Edge users worldwide and 5.4 billion Internet users. Around 600 million people have used Microsoft Edge at least once. Microsoft Bing is the second most used global search engine.
-- [Market share for mobile, browsers, operating... | NetMarketShare](https://netmarketshare.com/) — Mobile market share and desktop market share data.This journey began with reporting on the browser wars, and was one of the most fascinating and fun products anyone could hope to work on. All the best, The NetMarketshare Team.
-- [Browser Market Share 2025 (Popularity & Usage Statistics)](https://www.yaguara.co/browser-market-share/) — Find out which browsers dominate in 2025. Full usage stats by OS, region, and popularity, with a complete breakdown of browser market share .
-- [Battle for Top CRM Salesforce CRM vs Microsoft CRM](https://www.linkedin.com/pulse/battle-top-crm-salesforce-vs-microsoft-sowmiyanarayanan-srinivasan-3mkwe) — Market Leader: Salesforce dominates the CRM market with a 23.2% market share as of 2023 according to IDC. It is known for its comprehensive CRM platform that includes sales, marketing , customer service, and analytics tools.
-- [Microsoft reminds of Windows 10 support ending in 30 days](https://www.bleepingcomputer.com/news/microsoft/microsoft-reminds-of-windows-10-support-ending-in-30-days/) — Microsoft to force install the Microsoft 365 Copilot app in October. Microsoft says Windows September updates break SMBv1 shares .
-- [2025's CMS Market Share Report - Latest Trends and Usage Stats](https://www.wpbeginner.com/research/cms-market-share-report-latest-trends-and-usage-stats/) — We’ve divided our CMS market share and market size report into several different categories. Simply use the table of contents below to jump straight to the statistics or content management system you’re most interested in: CMS Usage Statistics.
-- [What's Next for Industry](https://news.microsoft.com/industry) — Microsoft Industry Cloud Overview · Microsoft Cloud for Financial Services · Introducing Microsoft Cloud for Manufacturing · Microsoft Cloud for Retail Overview ...
-- [Download Center - Microsoft 2024 Annual Report](https://www.microsoft.com/investor/reports/ar24/download-center/) — Available Information · Discussion & Analysis · Market Risk · Income Statements ... Microsoft 2024 Annual Report . View Online | Download. Microsoft 2024 10-K.
-- [Microsoft | MSFT Stock Price, Company Overview & News](https://www.forbes.com/companies/microsoft/) — Microsoft Corp. engages in the development and support of software, services, devices, and solutions. It operates through the following business segments:
-- [Industry trends Archives - Microsoft in Business Blogs](https://www.microsoft.com/en-us/industry/microsoft-in-business/content-type/industry-trends/) — The Microsoft AI in Education report reveals that 47% of leaders in education use AI daily. However, a gap in AI literacy is emerging. A woman holding a ...
-- [Microsoft Corporation - AnnualReports.com](https://www.annualreports.com/Company/microsoft-corporation) — Founded in 1975, Microsoft (Nasdaq “MSFT” @microsoft) is the leading platform and productivity company for the mobile-first, cloud-first world.
+- [Wikipedia Usage share of operating systems - Wikipedia](https://en.wikipedia.org/wiki/Usage_share_of_operating_systems) — 1 week ago - For smartphones and other mobile devices, Android has 72% market share, and Apple's iOS has 28%. For desktop computers and laptops, Microsoft Windows has 71% , followed by Apple's macOS at 16%, unknown operating systems at 8%, desktop Linux at 4%, then Google's ChromeOS at 2%.
+- [Statista Microsoft - statistics & facts | Statista](https://www.statista.com/topics/823/microsoft/) — This move, powered by innovative tools like ChatGPT and Copilot, further cements its position as a tech titan with a rich history and ambitious plans. Notably, Microsoft has surpassed Apple in market capitalization as a tech giant in 2024 , showcasing its ongoing pursuit of dominance.
+- [SignHouse Microsoft Revenue and Growth Statistics (2024) - SignHouse](https://usesignhouse.com/blog/microsoft-stats/) — August 1, 2024 - Some amazing facts about Microsoft Microsoft is a top tech company with a 21% market share worldwide . In April 2023, Microsoft’s market cap reached $2.254 trillion, showing its industry dominance. In FY2022, Microsoft was valued at $1.7 trillion, a 29.10% drop from its peak of $2.4 trillion ...
+- [Microsoft 2024 Annual Report](https://www.microsoft.com/investor/reports/ar24/?msockid=0b29fdf7f1d866c11c33eb9ef0106753) — Jun 23, 2025 · Fiscal year 2024 was a pivotal year for Microsoft. We entered our 50th year as a company and the second year of the AI platform shift. With these milestones, I’ve found myself …
+- [Microsoft Market share relative to its competitors, as of Q2 ...](https://csimarket.com/stocks/competitionSEG2.php?code=MSFT) — 5 days ago · Microsoft's Q2 2025 quarter and 12 months market share, relative to the MSFT's competitors. Based on total revenues.
+- [Cloud Market Share Q1 2025: AWS Dips, Microsoft And Google ...](https://www.crn.com/news/cloud/2025/cloud-market-share-q1-2025-aws-dips-microsoft-and-google-show-growth) — May 8, 2025 · Microsoft’s global cloud market share has fluctuated between 20 percent share and 25 percent share for the past several years.
+- [MSFT: Microsoft - Full Company Report - Zacks.com](https://www.zacks.com/stock/research/MSFT/company-reports) — 6 days ago · Microsoft Corporation is one of the largest broad-based technology providers in the world. The company dominates the PC software market with more than 73% of the market …
+- [Microsoft Statistics (2025): Growth, Revenue, and Market Cap](https://www.skillademia.com/statistics/microsoft-statistics/) — Apr 7, 2025 · Discover the latest Microsoft statistics, revealing insights into its operational prowess, market dominance, and strategic moves.
+- [6sense Microsoft - Market Share, Competitor Insights in Applications Suite](https://www.6sense.com/tech/applications-suite/microsoft-market-share) — Microsoft has market share of 9.62% in applications-suite market. Microsoft competes with 89 competitor tools in applications-suite category.
+- [HG Insights Microsoft Azure Market Share & Buyer Landscape Report](https://hginsights.com/blog/microsoft-azure-market-share-report) — February 11, 2025 - Microsoft Azure market share reached 24% of the global cloud market in 2024 . Discover insights into the Azure ecosystem and how it compares to AWS and GCP.
+- [Microsoft 2024 Annual Report](https://www.microsoft.com/investor/reports/ar24/?msockid=0b29fdf7f1d866c11c33eb9ef0106753) — Jun 23, 2025 · Fiscal year 2024 was a pivotal year for Microsoft. We entered our 50th year as a company and the second year of the AI platform shift. With these milestones, I’ve found myself …
+- [Microsoft Industry Clouds](https://www.microsoft.com/en-us/industry?msockid=0b29fdf7f1d866c11c33eb9ef0106753) — Accelerate digital transformation with industry solutions built on the Microsoft Cloud.
+- [Microsoft 2025 annual Work Trend Index](https://news.microsoft.com/annual-work-trend-index-2025/?msockid=0b29fdf7f1d866c11c33eb9ef0106753) — Today’s work is pushing the limits of humans alone, keeping employees from high-value tasks that drive growth and innovation. The Microsoft 365 Copilot app is designed to enable people and …
+- [What's Next for Industry - news. microsoft .com](https://news.microsoft.com/industry/?msockid=0b29fdf7f1d866c11c33eb9ef0106753) — We’re announcing another milestone in our efforts to support and co-innovate with customers and partners with the announcement of three new industry-specific solutions: Microsoft Cloud for …
+- [Microsoft - statistics & facts | Statista](https://www.statista.com/topics/823/microsoft/) — Mar 7, 2025 · Research expert covering cloud computing and emerging tech industries. Find the latest statistics on Microsoft, one of the largest cloud and computer software providers in the …
 
 ## Competitors
 - Top 15 Microsoft Competitors & Alternatives (2025)
-- While Microsoft has dominated many markets
-- competitors
-- Comparably Microsoft Competitors   Comparably
-- Microsoft competitors include Google
-- Apple
-- Sony
-- and Yahoo.
-- Marketing91 Top 26 Microsoft Alternatives & Competitors in 2025
-- November 28
-- 2024 - The top Microsoft competitors are Google (Alphabet Inc.)
+- Aug 1
+- whether in cloud computing
+- productivity …
+- Top 26 Microsoft Competitors & Alternatives in 2025
+- Nov 28
+- 2024 · The top Microsoft competitors are Google (Alphabet Inc.)
 - Amazon (Amazon Web Services)
 - Apple Inc.
 - Oracle
 - IBM (Including Red Hat)
+- Salesforce
+- Adobe and others.
+- Top Microsoft Competitors and Alternatives   Craft.co
+- Microsoft 's main competitors include Oracle

--- a/sales-prep-ui/demo.html
+++ b/sales-prep-ui/demo.html
@@ -199,12 +199,8 @@
                             <span class="text-sm font-medium text-gray-700">Draft Email</span>
                         </label>
                         <label class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
-                            <input type="checkbox" class="w-5 h-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500" value="contractDetails">
-                            <span class="text-sm font-medium text-gray-700">Contract Details</span>
-                        </label>
-                        <label class="flex items-center gap-3 p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer">
-                            <input type="checkbox" class="w-5 h-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500" value="priorCorrespondence">
-                            <span class="text-sm font-medium text-gray-700">Prior Correspondence</span>
+                            <input type="checkbox" class="w-5 h-5 text-blue-600 border-gray-300 rounded focus:ring-blue-500" value="exportMarkdown">
+                            <span class="text-sm font-medium text-gray-700">Export Markdown</span>
                         </label>
                     </div>
                 </div>
@@ -243,13 +239,9 @@
                                 <i data-lucide="chevron-up" class="w-4 h-4"></i>
                                 Collapse All
                             </button>
-                            <button onclick="exportResults('pdf')" class="flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm transition-colors">
+                            <button onclick="exportResults('markdown')" class="flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm transition-colors">
                                 <i data-lucide="file-text" class="w-4 h-4"></i>
-                                Export PDF
-                            </button>
-                            <button onclick="exportResults('email')" class="flex items-center gap-2 px-4 py-2 bg-blue-100 hover:bg-blue-200 text-blue-700 rounded-lg text-sm transition-colors">
-                                <i data-lucide="mail" class="w-4 h-4"></i>
-                                Email Summary
+                                Export Markdown
                             </button>
                         </div>
                     </div>
@@ -289,140 +281,141 @@
             document.getElementById('productDescription').innerHTML = `<p class="text-sm text-blue-800">${productDescriptions[selectedProduct]}</p>`;
         }
 
-        function generateResults() {
+        async function generateResults() {
             const companyName = document.getElementById('companyName').value;
+            const companyWebsite = document.getElementById('companyWebsite').value;
             const selectedProduct = document.getElementById('selectedProduct').value;
-            const checkboxes = document.querySelectorAll('input[type="checkbox"]:checked');
-            
-            if (!companyName || checkboxes.length === 0) {
+            const checked = Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+
+            if (!companyName || checked.length === 0) {
                 alert('Please enter a company name and select at least one research option.');
                 return;
             }
 
-            // Show progress section and hide results
+            // Show progress, disable button
             document.getElementById('progress-section').classList.remove('hidden');
             document.getElementById('results-section').classList.add('hidden');
-            document.getElementById('generate-btn').disabled = true;
-            document.getElementById('generate-btn').innerHTML = '<i data-lucide="loader" class="w-5 h-5 animate-spin"></i> Generating...';
-            
-            // Simulate progress
-            simulateProgress(companyName, selectedProduct, checkboxes);
-        }
+            const btn = document.getElementById('generate-btn');
+            btn.disabled = true;
+            btn.innerHTML = '<i data-lucide="loader" class="w-5 h-5 animate-spin"></i> Generating...';
+            lucide.createIcons();
 
-        function simulateProgress(companyName, selectedProduct, checkboxes) {
-            const progressSteps = [
-                { text: 'Gathering company data...', duration: 1000 },
-                { text: 'Analyzing financial information...', duration: 1500 },
-                { text: 'Collecting news and press releases...', duration: 1200 },
-                { text: 'Identifying key stakeholders...', duration: 1000 },
-                { text: 'Generating personalized insights...', duration: 800 },
-                { text: 'Finalizing research report...', duration: 500 }
-            ];
+            // Build researchOptions flags
+            const researchOptions = {};
+            checked.forEach(key => researchOptions[key] = true);
 
-            let currentStep = 0;
-            let progress = 0;
-            const totalDuration = progressSteps.reduce((sum, step) => sum + step.duration, 0);
-
-            function updateProgress() {
-                if (currentStep < progressSteps.length) {
-                    const step = progressSteps[currentStep];
-                    const stepProgress = (step.duration / totalDuration) * 100;
-                    
-                    // Update progress bar
-                    progress += stepProgress;
-                    document.getElementById('progress-bar').style.width = Math.min(progress, 100) + '%';
-                    document.getElementById('progress-percentage').textContent = Math.round(Math.min(progress, 100)) + '%';
-                    
-                    // Update step text
-                    const stepsContainer = document.getElementById('progress-steps');
-                    stepsContainer.innerHTML = `
-                        <div class="flex items-center gap-3 text-sm">
-                            <i data-lucide="loader" class="w-4 h-4 animate-spin text-blue-600"></i>
-                            <span class="text-gray-600">${step.text}</span>
-                        </div>
-                    `;
-                    
-                    currentStep++;
-                    setTimeout(updateProgress, step.duration);
-                } else {
-                    // Complete - show results
-                    setTimeout(() => {
-                        showResults(companyName, selectedProduct, checkboxes);
-                    }, 500);
-                }
+            try {
+                const resp = await fetch('http://localhost:3001/api/research', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ companyName, companyWebsite, selectedProduct, researchOptions })
+                });
+                if (!resp.ok) throw new Error('API error');
+                const data = await resp.json();
+                renderResults(companyName, selectedProduct, researchOptions, data);
+            } catch (e) {
+                alert('Failed to generate research. Please ensure the Next.js app is running on http://localhost:3001');
+            } finally {
+                document.getElementById('progress-section').classList.add('hidden');
+                btn.disabled = false;
+                btn.innerHTML = '<i data-lucide="search" class="w-5 h-5"></i> Generate Research Results';
+                lucide.createIcons();
             }
-
-            updateProgress();
         }
 
-        function showResults(companyName, selectedProduct, checkboxes) {
-            // Hide progress, show results
-            document.getElementById('progress-section').classList.add('hidden');
+        function renderResults(companyName, selectedProduct, researchOptions, payload) {
             document.getElementById('results-section').classList.remove('hidden');
-            
-            // Reset button
-            document.getElementById('generate-btn').disabled = false;
-            document.getElementById('generate-btn').innerHTML = '<i data-lucide="search" class="w-5 h-5"></i> Generate Research Results';
-            
-            // Generate mock results
             const resultsContent = document.getElementById('results-content');
-            resultsContent.innerHTML = `
+            resultsContent.innerHTML = '';
+
+            // Success banner
+            const count = Object.keys(researchOptions).length;
+            resultsContent.innerHTML += `
                 <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6">
                     <div class="flex items-center gap-2">
                         <i data-lucide="check-circle" class="w-5 h-5 text-green-600"></i>
                         <span class="text-green-800 font-medium">Research completed successfully!</span>
                     </div>
-                    <p class="text-green-700 text-sm mt-1">Generated ${checkboxes.length} research categories for ${companyName}</p>
+                    <p class="text-green-700 text-sm mt-1">Generated ${count} research categories for ${companyName}</p>
                 </div>
-                <h3 class="text-xl font-semibold mb-4">Research Results for ${companyName}</h3>
             `;
-            
-            checkboxes.forEach(checkbox => {
-                const option = checkbox.value;
-                const resultCard = createResultCard(option, companyName, selectedProduct);
-                resultsContent.appendChild(resultCard);
-            });
 
-            // Scroll to results
+            const results = payload.results || {};
+
+            // Helper to add a collapsible card
+            function addCard(key, title, html) {
+                if (!researchOptions[key]) return;
+                const id = `content-${key}`;
+                resultsContent.innerHTML += `
+                    <div class="border border-gray-200 rounded-lg">
+                        <button onclick="toggleResult('${key}')" class="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50">
+                            <span class="font-medium text-gray-800">${title}</span>
+                            <i data-lucide="chevron-up" class="w-5 h-5 text-gray-500" id="icon-${key}"></i>
+                        </button>
+                        <div id="${id}" class="px-4 pb-4 border-t border-gray-200">
+                            <div class="pt-4">${html}</div>
+                        </div>
+                    </div>
+                `;
+            }
+
+            // Build sections
+            if (researchOptions.companyHistory && results.companyHistory) {
+                addCard('companyHistory', 'Company History', `<div class="whitespace-pre-wrap text-sm">${escapeHtml(results.companyHistory.executiveBrief || '')}</div>`);
+            }
+            if (researchOptions.existingProducts && results.existingProducts) {
+                addCard('existingProducts', 'Existing Products / Offerings (Signals)', `<div class="whitespace-pre-wrap text-sm">${escapeHtml(results.existingProducts.adsOpportunities || '')}</div>`);
+            }
+            if (researchOptions.financialInfo && results.financialInfo) {
+                const items = results.financialInfo.earnings || [];
+                const html = items.map(d => `- <a href="${d.url}" class="text-blue-600 hover:underline" target="_blank">${escapeHtml(d.title)}</a>${d.date ? ` <span class='text-gray-500 text-xs'>(${escapeHtml(d.date)})</span>` : ''}`).join('<br>');
+                addCard('financialInfo', 'Financial Information (Earnings/IR)', `<div class="text-sm">${html || 'No items found'}</div>`);
+            }
+            if (researchOptions.newsArticles && results.newsArticles) {
+                const items = results.newsArticles.press || [];
+                const html = items.map(d => `- <a href="${d.url}" class="text-blue-600 hover:underline" target="_blank">${escapeHtml(d.title)}</a>${d.date ? ` <span class='text-gray-500 text-xs'>(${escapeHtml(d.date)})</span>` : ''}`).join('<br>');
+                addCard('newsArticles', 'News Articles & Press', `<div class="text-sm">${html || 'No items found'}</div>`);
+            }
+            if (researchOptions.industryDeepDive && results.industryDeepDive) {
+                const items = results.industryDeepDive.industry || [];
+                const html = items.map(d => `- <a href="${d.url}" class="text-blue-600 hover:underline" target="_blank">${escapeHtml(d.title)}</a>${d.date ? ` <span class='text-gray-500 text-xs'>(${escapeHtml(d.date)})</span>` : ''}`).join('<br>');
+                addCard('industryDeepDive', 'Industry Deep Dive', `<div class="text-sm">${html || 'No items found'}</div>`);
+            }
+            if (researchOptions.competitorsTrends && results.competitorsTrends) {
+                const items = results.competitorsTrends.competitors || [];
+                const html = items.map(c => `- ${escapeHtml(c)}`).join('<br>');
+                addCard('competitorsTrends', 'Competitors & Market Trends', `<div class="text-sm">${html || 'No items found'}</div>`);
+            }
+            if (researchOptions.draftEmail && results.draftEmail) {
+                const { subject, body } = results.draftEmail;
+                addCard('draftEmail', 'Draft Email', `
+                    <div class="space-y-3">
+                        <div><strong>Subject:</strong> ${escapeHtml(subject || '')}</div>
+                        <pre class="mt-2 p-3 bg-gray-50 rounded text-sm whitespace-pre-wrap">${escapeHtml(body || '')}</pre>
+                    </div>
+                `);
+            }
+            if (researchOptions.exportMarkdown && results.exportMarkdown) {
+                addCard('exportMarkdown', 'Export (Markdown)', `
+                    <textarea class="w-full p-3 border rounded text-sm" rows="10">${escapeHtml(results.exportMarkdown)}</textarea>
+                `);
+            }
+
             document.getElementById('results-section').scrollIntoView({ behavior: 'smooth' });
             lucide.createIcons();
         }
 
-        function createResultCard(option, companyName, selectedProduct) {
-            const card = document.createElement('div');
-            card.className = 'border border-gray-200 rounded-lg';
-            
-            const mockData = getMockData(option, companyName, selectedProduct);
-            
-            card.innerHTML = `
-                <button onclick="toggleResult('${option}')" class="w-full flex items-center justify-between p-4 text-left hover:bg-gray-50">
-                    <span class="font-medium text-gray-800 capitalize">${option.replace(/([A-Z])/g, ' $1').trim()}</span>
-                    <i data-lucide="chevron-up" class="w-5 h-5 text-gray-500" id="icon-${option}"></i>
-                </button>
-                <div id="content-${option}" class="px-4 pb-4 border-t border-gray-200">
-                    <div class="pt-4">
-                        ${mockData}
-                    </div>
-                </div>
-            `;
-            
-            return card;
-        }
-
         function toggleResult(option) {
-            const content = document.getElementById(`content-${option}`);
+            const content = document.getElementById(`content-${option}`) || document.getElementById(`content-${option}`);
             const icon = document.getElementById(`icon-${option}`);
-            
+            if (!content || !icon) return;
             if (content.classList.contains('hidden')) {
-                // Expand
                 content.classList.remove('hidden');
                 icon.setAttribute('data-lucide', 'chevron-up');
             } else {
-                // Collapse
                 content.classList.add('hidden');
                 icon.setAttribute('data-lucide', 'chevron-down');
             }
-            
             lucide.createIcons();
         }
 
@@ -431,173 +424,40 @@
             const toggleIcon = toggleBtn.querySelector('i');
             const allContents = document.querySelectorAll('[id^="content-"]');
             const allIcons = document.querySelectorAll('[id^="icon-"]');
-            
-            // Check if any content is visible
             const hasVisibleContent = Array.from(allContents).some(content => !content.classList.contains('hidden'));
-            
             if (hasVisibleContent) {
-                // Collapse all
                 allContents.forEach(content => content.classList.add('hidden'));
                 allIcons.forEach(icon => icon.setAttribute('data-lucide', 'chevron-down'));
                 toggleIcon.setAttribute('data-lucide', 'chevron-down');
                 toggleBtn.innerHTML = '<i data-lucide="chevron-down" class="w-4 h-4"></i> Expand All';
             } else {
-                // Expand all
                 allContents.forEach(content => content.classList.remove('hidden'));
                 allIcons.forEach(icon => icon.setAttribute('data-lucide', 'chevron-up'));
                 toggleIcon.setAttribute('data-lucide', 'chevron-up');
                 toggleBtn.innerHTML = '<i data-lucide="chevron-up" class="w-4 h-4"></i> Collapse All';
             }
-            
             lucide.createIcons();
         }
 
-        function getMockData(option, companyName, selectedProduct) {
-            const mockData = {
-                companyHistory: `
-                    <div class="space-y-2">
-                        <p><strong>Founded:</strong> 2015</p>
-                        <p><strong>Headquarters:</strong> San Francisco, CA</p>
-                        <p><strong>Employees:</strong> 500-1000</p>
-                        <p><strong>Industry:</strong> Technology</p>
-                        <p><strong>Description:</strong> ${companyName} is a leading technology company focused on innovation and customer success.</p>
-                    </div>
-                `,
-                existingProducts: `
-                    <div class="space-y-2">
-                        <p><strong>Products:</strong> Enterprise Software, Cloud Services, AI Solutions</p>
-                        <p><strong>Services:</strong> Consulting, Implementation, Support</p>
-                    </div>
-                `,
-                financialInfo: `
-                    <div class="space-y-2">
-                        <p><strong>Revenue:</strong> $50M</p>
-                        <p><strong>Growth Rate:</strong> 15%</p>
-                        <p><strong>Market Cap:</strong> Private</p>
-                        <p><strong>Profitability:</strong> Profitable</p>
-                    </div>
-                `,
-                newsArticles: `
-                    <div class="space-y-3">
-                        <div class="border-l-4 border-blue-500 pl-4">
-                            <h4 class="font-semibold">${companyName} announces new product launch</h4>
-                            <p class="text-sm text-gray-600">2024-01-15 - TechCrunch</p>
-                            <p class="text-sm">Company launches innovative solution for enterprise customers</p>
-                        </div>
-                    </div>
-                `,
-                industryDeepDive: `
-                    <div class="space-y-2">
-                        <p><strong>Market Size:</strong> $100B</p>
-                        <p><strong>Trends:</strong> AI Integration, Cloud Migration, Digital Transformation</p>
-                        <p><strong>Challenges:</strong> Talent Shortage, Regulatory Compliance</p>
-                    </div>
-                `,
-                competitorsTrends: `
-                    <div class="space-y-2">
-                        <p><strong>Competitors:</strong> Competitor A, Competitor B, Competitor C</p>
-                        <p><strong>Market Position:</strong> Top 3</p>
-                        <p><strong>Differentiators:</strong> Innovation, Customer Service, Pricing</p>
-                    </div>
-                `,
-                keyStakeholders: `
-                    <div class="space-y-3">
-                        <div class="flex items-center gap-4 p-3 bg-gray-50 rounded">
-                            <div>
-                                <p class="font-semibold">John Smith</p>
-                                <p class="text-sm text-gray-600">CEO</p>
-                            </div>
-                            <a href="#" class="text-blue-600 hover:underline text-sm">LinkedIn Profile</a>
-                        </div>
-                        <div class="flex items-center gap-4 p-3 bg-gray-50 rounded">
-                            <div>
-                                <p class="font-semibold">Jane Doe</p>
-                                <p class="text-sm text-gray-600">CTO</p>
-                            </div>
-                            <a href="#" class="text-blue-600 hover:underline text-sm">LinkedIn Profile</a>
-                        </div>
-                    </div>
-                `,
-                draftEmail: `
-                    <div class="space-y-3">
-                        <div>
-                            <strong>Subject:</strong> LinkedIn ${selectedProduct} Opportunity for ${companyName}
-                        </div>
-                        <div>
-                            <strong>Body:</strong>
-                            <pre class="mt-2 p-3 bg-gray-50 rounded text-sm whitespace-pre-wrap">Hi [Name],
-
-I hope this email finds you well. I've been following ${companyName}'s impressive growth and wanted to reach out about how LinkedIn ${selectedProduct} could help accelerate your success.
-
-Based on your company's focus on [industry], I believe we could provide significant value through [specific benefits].
-
-Would you be available for a brief 15-minute call next week to discuss how LinkedIn can support ${companyName}'s goals?
-
-Best regards,
-[Your Name]</pre>
-                        </div>
-                    </div>
-                `,
-                contractDetails: `
-                    <div class="space-y-2">
-                        <p><strong>Current Contract:</strong> LinkedIn Talent Solutions</p>
-                        <p><strong>Renewal Date:</strong> 2024-06-30</p>
-                        <p><strong>Contract Value:</strong> $50K</p>
-                        <p><strong>Usage:</strong> Active</p>
-                    </div>
-                `,
-                priorCorrespondence: `
-                    <div class="space-y-3">
-                        <div class="border-l-4 border-green-500 pl-4">
-                            <p><strong>Email</strong> - 2024-01-10</p>
-                            <p class="text-sm">Initial outreach about LinkedIn Learning Solutions</p>
-                            <p class="text-sm text-green-600"><strong>Outcome:</strong> Positive response, meeting scheduled</p>
-                        </div>
-                    </div>
-                `
-            };
-            
-            return mockData[option] || '<p class="text-gray-600">No data available for this option.</p>';
-        }
-
         function exportResults(format) {
-            const companyName = document.getElementById('companyName').value;
-            const selectedProduct = document.getElementById('selectedProduct').value;
-            
-            if (format === 'pdf') {
-                // Simulate PDF export
-                alert(`PDF export initiated for ${companyName} research report.\n\nThis would generate a comprehensive PDF with all research data, formatted for presentation to clients.`);
-            } else if (format === 'email') {
-                // Simulate email export
-                const emailContent = generateEmailSummary(companyName, selectedProduct);
-                alert(`Email summary generated!\n\nSubject: LinkedIn ${selectedProduct} Research Summary - ${companyName}\n\n${emailContent}`);
+            const textarea = document.querySelector('#content-exportMarkdown textarea');
+            if (format === 'markdown' && textarea) {
+                const blob = new Blob([textarea.value], { type: 'text/markdown;charset=utf-8' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'sales-prep.md';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            } else {
+                alert('Enable "Export Markdown" option to generate downloadable content.');
             }
         }
 
-        function generateEmailSummary(companyName, selectedProduct) {
-            return `Hi Team,
-
-I've completed the research for ${companyName} and wanted to share the key insights for our upcoming ${selectedProduct} pitch:
-
-Key Findings:
-• Company Size: 500-1000 employees
-• Industry: Technology
-• Growth Rate: 15% YoY
-• Key Stakeholders: John Smith (CEO), Jane Doe (CTO)
-• Recent News: Product launch announcement
-
-Recommended Approach:
-Focus on how LinkedIn ${selectedProduct} can help ${companyName} scale their hiring/learning/marketing/sales efforts given their current growth trajectory.
-
-Next Steps:
-1. Schedule discovery call with key stakeholders
-2. Prepare customized demo based on their specific needs
-3. Follow up with personalized proposal
-
-Let me know if you need any additional information for the pitch.
-
-Best regards,
-[Your Name]`;
+        function escapeHtml(s) {
+            return (s || '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
         }
     </script>
 </body>

--- a/sales-prep-ui/src/app/api/research/route.ts
+++ b/sales-prep-ui/src/app/api/research/route.ts
@@ -7,6 +7,18 @@ import os from 'os';
 
 const execFileAsync = promisify(execFile);
 
+type ResearchOptions = {
+  companyHistory?: boolean;
+  existingProducts?: boolean;
+  financialInfo?: boolean;
+  newsArticles?: boolean;
+  industryDeepDive?: boolean;
+  competitorsTrends?: boolean;
+  keyStakeholders?: boolean; // not implemented in backend yet
+  draftEmail?: boolean;
+  exportMarkdown?: boolean;
+};
+
 function toLOB(selectedProduct?: string): 'LTS' | 'LLS' | 'LMS' | 'LSS' | undefined {
   if (!selectedProduct) return undefined;
   const p = selectedProduct.toLowerCase();
@@ -54,10 +66,76 @@ async function runCompanyIntel(pythonPath: string, args: string[], cwd: string) 
   return execFileAsync(pythonPath, args, { cwd });
 }
 
+function buildMarkdownExport(companyName: string, summary: any, data: any, lob?: string, selected?: ResearchOptions): string {
+  const lines: string[] = [];
+  lines.push(`# ${companyName} — Sales Prep ${lob ? `(Focus: ${lob})` : ''}`.trim());
+  if (summary?.pitch_headlines?.length) {
+    lines.push('## Top Headlines');
+    for (const h of summary.pitch_headlines.slice(0, 3)) lines.push(`- ${h}`);
+    lines.push('');
+  }
+  if (selected?.companyHistory) {
+    lines.push('## Company History');
+    lines.push(summary?.executive_brief || '');
+    lines.push('');
+  }
+  if (selected?.existingProducts) {
+    lines.push('## Existing Products/Offerings (Signals)');
+    lines.push(summary?.ads_opportunities || '');
+    lines.push('');
+  }
+  if (selected?.financialInfo) {
+    lines.push('## Financial Info (Earnings/IR)');
+    for (const d of (data?.earnings_reports || []).slice(0, 5)) {
+      const t = d.title || 'Untitled';
+      const url = d.url || '';
+      const date = d.published_at ? ` (${d.published_at})` : '';
+      lines.push(`- [${t}](${url})${date}`);
+    }
+    lines.push('');
+  }
+  if (selected?.newsArticles) {
+    lines.push('## News Articles');
+    for (const d of (data?.press_releases || []).slice(0, 5)) {
+      const t = d.title || 'Untitled';
+      const url = d.url || '';
+      const date = d.published_at ? ` (${d.published_at})` : '';
+      lines.push(`- [${t}](${url})${date}`);
+    }
+    lines.push('');
+  }
+  if (selected?.industryDeepDive) {
+    lines.push('## Industry Deep Dive');
+    for (const d of (data?.industry_reports || []).slice(0, 5)) {
+      const t = d.title || 'Untitled';
+      const url = d.url || '';
+      const date = d.published_at ? ` (${d.published_at})` : '';
+      lines.push(`- [${t}](${url})${date}`);
+    }
+    lines.push('');
+  }
+  if (selected?.competitorsTrends) {
+    lines.push('## Competitors & Market Trends');
+    for (const c of (data?.competitors || []).slice(0, 15)) lines.push(`- ${c}`);
+    lines.push('');
+  }
+  if (selected?.draftEmail) {
+    lines.push('## Draft Email');
+    const subject = `LinkedIn ${lob || ''} Opportunity for ${companyName}`.trim();
+    const body = `Hi [Name],\n\nI noticed ${companyName}'s recent updates — ${
+      (summary?.pitch_headlines && summary.pitch_headlines[0]) || 'recent press and industry signals'
+    }. Based on ${lob || 'LinkedIn solutions'}, we can help you reach the right audiences and tie impact to outcomes.\n\nA quick idea: ${summary?.outbound_prep || 'pilot a targeted campaign aligned to current priorities.'}\n\nBest,\n[Your Name]`;
+    lines.push(`Subject: ${subject}`);
+    lines.push('');
+    lines.push(body);
+  }
+  return lines.join('\n');
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { companyName, companyWebsite, selectedProduct } = body || {};
+    const { companyName, companyWebsite, selectedProduct, researchOptions } = body || {} as { researchOptions?: ResearchOptions };
 
     if (!companyName || !companyWebsite || !selectedProduct) {
       return NextResponse.json(
@@ -75,64 +153,42 @@ export async function POST(request: NextRequest) {
     const { cacheDir, jsonPath: cachedJson } = cachePaths(workspaceRoot, companyName, lob);
     await ensureDir(cacheDir);
     const TTL_MS = 15 * 60 * 1000;
+    let report: any | null = null;
     if (await isFresh(cachedJson, TTL_MS)) {
       const raw = await fs.readFile(cachedJson, 'utf-8');
-      const report = JSON.parse(raw);
-      const summary = report.summary || {};
-      const data = report.data || {};
-      const results = {
-        topHeadlines: (summary.pitch_headlines || []).slice(0, 3),
-        lob: summary.selected_lob || lob,
-        lobFocus: summary.lob_focus || null,
-        executiveBrief: summary.executive_brief || '',
-        renewalPrep: summary.renewal_prep || '',
-        outboundPrep: summary.outbound_prep || '',
-        adsOpportunities: summary.ads_opportunities || '',
-        recruitingNotes: summary.recruiting_notes || '',
-        risksFlags: summary.risks_flags || '',
-        press: (data.press_releases || []).map((d: any) => ({ title: d.title, url: d.url, snippet: d.snippet, date: d.published_at || null })),
-        earnings: (data.earnings_reports || []).map((d: any) => ({ title: d.title, url: d.url, snippet: d.snippet, date: d.published_at || null })),
-        industry: (data.industry_reports || []).map((d: any) => ({ title: d.title, url: d.url, snippet: d.snippet, date: d.published_at || null })),
-        competitors: data.competitors || [],
-      };
-      return NextResponse.json({ companyName, companyWebsite, selectedProduct, results, cached: true });
-    }
+      report = JSON.parse(raw);
+    } else {
+      // Prepare temp output files for this invocation
+      const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'companyintel-'));
+      const mdOut = path.join(tmpDir, 'report.md');
+      const jsonOut = path.join(tmpDir, 'report.json');
 
-    // Prepare temp output files for this invocation
-    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'companyintel-'));
-    const mdOut = path.join(tmpDir, 'report.md');
-    const jsonOut = path.join(tmpDir, 'report.json');
+      const baseArgs = ['-m', 'companyintel.cli', '--name', companyName, '--website', companyWebsite, '--out', mdOut, '--json', jsonOut];
+      if (lob) baseArgs.push('--lob', lob);
 
-    const baseArgs = ['-m', 'companyintel.cli', '--name', companyName, '--website', companyWebsite, '--out', mdOut, '--json', jsonOut];
-    if (lob) baseArgs.push('--lob', lob);
-
-    // Try python candidates until one succeeds
-    let lastError: any = null;
-    for (const py of pythonCandidates(workspaceRoot)) {
-      try {
-        await runCompanyIntel(py, baseArgs, workspaceRoot);
-        lastError = null;
-        break;
-      } catch (err) {
-        lastError = err;
+      // Try python candidates until one succeeds
+      let lastError: any = null;
+      for (const py of pythonCandidates(workspaceRoot)) {
+        try {
+          await runCompanyIntel(py, baseArgs, workspaceRoot);
+          lastError = null;
+          break;
+        } catch (err) {
+          lastError = err;
+        }
       }
+      if (lastError) throw lastError;
+
+      const raw = await fs.readFile(jsonOut, 'utf-8');
+      report = JSON.parse(raw);
+      await fs.writeFile(cachedJson, raw, 'utf-8');
     }
-    if (lastError) {
-      throw lastError;
-    }
 
-    // Read CLI output JSON
-    const raw = await fs.readFile(jsonOut, 'utf-8');
-    const report = JSON.parse(raw);
-
-    // Write to cache for reuse
-    await fs.writeFile(cachedJson, raw, 'utf-8');
-
-    // Map Python JSON into UI response shape
     const summary = report.summary || {};
     const data = report.data || {};
 
-    const results = {
+    // Build the full results
+    const full = {
       topHeadlines: (summary.pitch_headlines || []).slice(0, 3),
       lob: summary.selected_lob || lob,
       lobFocus: summary.lob_focus || null,
@@ -148,7 +204,41 @@ export async function POST(request: NextRequest) {
       competitors: data.competitors || [],
     };
 
-    return NextResponse.json({ companyName, companyWebsite, selectedProduct, results, cached: false });
+    // Filter by researchOptions
+    const sel: ResearchOptions = researchOptions || {};
+    const filtered: any = {};
+
+    if (sel.companyHistory) filtered.companyHistory = { executiveBrief: full.executiveBrief };
+    if (sel.existingProducts) filtered.existingProducts = { adsOpportunities: full.adsOpportunities };
+    if (sel.financialInfo) filtered.financialInfo = { earnings: full.earnings };
+    if (sel.newsArticles) filtered.newsArticles = { press: full.press };
+    if (sel.industryDeepDive) filtered.industryDeepDive = { industry: full.industry };
+    if (sel.competitorsTrends) filtered.competitorsTrends = { competitors: full.competitors };
+    if (sel.keyStakeholders) filtered.keyStakeholders = { note: 'Not implemented yet' };
+
+    if (sel.draftEmail) {
+      const subject = `LinkedIn ${full.lob || ''} Opportunity for ${companyName}`.trim();
+      const body = `Hi [Name],\n\nI noticed ${companyName}'s recent updates — ${
+        (full.topHeadlines && full.topHeadlines[0]) || 'recent press and industry signals'
+      }. Based on ${full.lob || 'LinkedIn solutions'}, we can help you reach the right audiences and tie impact to outcomes.\n\nA quick idea: ${full.outboundPrep || 'pilot a targeted campaign aligned to current priorities.'}\n\nBest,\n[Your Name]`;
+      filtered.draftEmail = { subject, body };
+    }
+
+    if (sel.exportMarkdown) {
+      filtered.exportMarkdown = buildMarkdownExport(companyName, summary, data, full.lob, sel);
+    }
+
+    // Always include some top-level context
+    const basePayload: any = {
+      companyName,
+      companyWebsite,
+      selectedProduct,
+      lob: full.lob,
+      topHeadlines: full.topHeadlines,
+      results: filtered,
+    };
+
+    return NextResponse.json(basePayload);
   } catch (error) {
     console.error('Research API error:', error);
     return NextResponse.json(

--- a/sales-prep-ui/src/app/layout.tsx
+++ b/sales-prep-ui/src/app/layout.tsx
@@ -1,15 +1,17 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Roboto_Mono } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const interSans = Inter({
+  variable: "--font-inter-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const robotoMono = Roboto_Mono({
+  variable: "--font-roboto-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -24,9 +26,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${interSans.variable} ${robotoMono.variable} antialiased`}>
         {children}
       </body>
     </html>


### PR DESCRIPTION
This PR wires the sales-prep UI to the Python companyintel CLI via the Next.js API, adds researchOptions-based filtering, top headlines (linked+dated), Markdown export, caching, and Python path fallback.

Key changes:
- src/app/api/research/route.ts: run CLI, map JSON, cache, filter, draft email, export markdown
- demo.html: call API, render selected sections, export markdown
- layout.tsx: replace unsupported fonts with Inter/Roboto_Mono

Dev notes:
- Next on Node 18+
- Dev server on port 3001; demo points to that API.